### PR TITLE
feat: Renounce admin function

### DIFF
--- a/contract/contract/src/base/events.rs
+++ b/contract/contract/src/base/events.rs
@@ -44,6 +44,11 @@ pub fn contract_unpaused(env: &Env, admin: Address, timestamp: u64) {
     env.events().publish(topics, timestamp);
 }
 
+pub fn admin_renounced(env: &Env, admin: Address) {
+    let topics = (Symbol::new(env, "admin_renounced"), admin);
+    env.events().publish(topics, ());
+}
+
 pub fn emergency_contact_updated(env: &Env, admin: Address, contact: Address) {
     let topics = (Symbol::new(env, "emergency_contact_updated"), admin);
     env.events().publish(topics, contact);

--- a/contract/contract/src/crowdfunding.rs
+++ b/contract/contract/src/crowdfunding.rs
@@ -727,6 +727,19 @@ impl CrowdfundingTrait for CrowdfundingContract {
         Ok(())
     }
 
+    fn renounce_admin(env: Env) -> Result<(), CrowdfundingError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(CrowdfundingError::NotInitialized)?;
+        admin.require_auth();
+
+        env.storage().instance().remove(&StorageKey::Admin);
+        events::admin_renounced(&env, admin);
+        Ok(())
+    }
+
     fn is_paused(env: Env) -> bool {
         env.storage()
             .instance()
@@ -906,7 +919,7 @@ impl CrowdfundingTrait for CrowdfundingContract {
             .storage()
             .instance()
             .get(&metrics_key)
-            .unwrap_or(PoolMetrics::new());
+            .unwrap_or_default();
 
         metrics.total_raised -= contribution.amount;
         // Note: We don't decrement contributor_count as the contributor may have other contributions

--- a/contract/contract/src/interfaces/crowdfunding.rs
+++ b/contract/contract/src/interfaces/crowdfunding.rs
@@ -128,6 +128,8 @@ pub trait CrowdfundingTrait {
 
     fn is_closed(env: Env, pool_id: u64) -> Result<bool, CrowdfundingError>;
 
+    fn renounce_admin(env: Env) -> Result<(), CrowdfundingError>;
+
     fn get_active_campaign_count(env: Env) -> u32;
     fn verify_cause(env: Env, cause: Address) -> Result<(), CrowdfundingError>;
 

--- a/contract/contract/test/mod.rs
+++ b/contract/contract/test/mod.rs
@@ -1,4 +1,5 @@
 mod close_pool_test;
 mod create_pool;
 mod crowdfunding_test;
+mod renounce_admin_test;
 mod verify_cause;

--- a/contract/contract/test/renounce_admin_test.rs
+++ b/contract/contract/test/renounce_admin_test.rs
@@ -1,0 +1,89 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+use crate::{
+    base::errors::CrowdfundingError,
+    crowdfunding::{CrowdfundingContract, CrowdfundingContractClient},
+};
+
+fn setup_test(env: &Env) -> (CrowdfundingContractClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(CrowdfundingContract, ());
+    let client = CrowdfundingContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    client.initialize(&admin, &token_address, &0);
+
+    (client, admin, token_address)
+}
+
+#[test]
+fn test_renounce_admin_success() {
+    let env = Env::default();
+    let (client, _, _) = setup_test(&env);
+
+    // Initial state: admin exists and can perform admin actions
+    assert!(!client.is_paused());
+    client.pause();
+    assert!(client.is_paused());
+    client.unpause();
+    assert!(!client.is_paused());
+
+    // Renounce admin
+    client.renounce_admin();
+
+    // Verify admin is removed by trying an admin action
+    let result = client.try_pause();
+    assert_eq!(result, Err(Ok(CrowdfundingError::NotInitialized)));
+}
+
+#[test]
+fn test_renounce_admin_unauthorized() {
+    let env = Env::default();
+    let (client, _, _) = setup_test(&env);
+    let _non_admin = Address::generate(&env);
+
+    // unauthorized call is covered by require_auth in renounce_admin
+    // which is tested below via mock_auths
+}
+
+#[test]
+#[should_panic]
+fn test_renounce_admin_requires_admin_auth() {
+    let env = Env::default();
+    let (client, _, _) = setup_test(&env);
+    let non_admin = Address::generate(&env);
+
+    // Use specific mock_auths to ensure non_admin is the one calling
+    client
+        .mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "renounce_admin",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .renounce_admin();
+}
+
+#[test]
+fn test_renounce_admin_already_renounced() {
+    let env = Env::default();
+    let (client, _, _) = setup_test(&env);
+
+    client.renounce_admin();
+
+    // Try to renounce again
+    let result = client.try_renounce_admin();
+    assert_eq!(result, Err(Ok(CrowdfundingError::NotInitialized)));
+}


### PR DESCRIPTION
## Add `renounce_admin` Function to Crowdfunding Contract

### Summary
Implements an irreversible admin renouncement mechanism, allowing the current admin to permanently relinquish control of the crowdfunding contract.

### Changes

Closes #79

**New functionality (`renounce_admin`)** — the admin can now permanently remove themselves from the contract. Once renounced, all admin-gated actions (e.g. pause/unpause) become inaccessible, as the contract enters a `NotInitialized` state for admin lookups.

**Event emission** — a new `admin_renounced` event is emitted on successful renouncement, enabling off-chain listeners to react to the change in contract governance.

**Interface update** — `renounce_admin` is added to the `CrowdfundingTrait` interface, making it part of the public contract API.

**Minor refactor** — replaced an explicit `.unwrap_or(PoolMetrics::new())` with `.unwrap_or_default()` for cleaner idiom.

### Test Coverage
A dedicated `renounce_admin_test.rs` module covers:
- Successful renouncement and subsequent loss of admin privileges
- Double-renouncement returning `NotInitialized`
- Auth enforcement (non-admin callers cannot invoke the function)

### Notes
- This action is **irreversible** — there is no mechanism to reassign admin after renouncement. Callers should be certain before invoking.
- Any integrations relying on admin availability should handle `NotInitialized` errors gracefully post-renouncement.