### PR TITLE
feat: Add string length validation and corresponding error handling

### DIFF
--- a/contract/contract/src/base/errors.rs
+++ b/contract/contract/src/base/errors.rs
@@ -55,3 +55,10 @@ pub enum CrowdfundingError {
     UserBlacklisted = 49,
     CampaignCancelled = 50,
 }
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SecondCrowdfundingError {
+    StringTooLong = 1,
+}

--- a/contract/contract/src/base/types.rs
+++ b/contract/contract/src/base/types.rs
@@ -52,6 +52,7 @@ pub struct PoolMetadata {
 pub const MAX_DESCRIPTION_LENGTH: u32 = 500;
 pub const MAX_URL_LENGTH: u32 = 200;
 pub const MAX_HASH_LENGTH: u32 = 100;
+pub const MAX_STRING_LENGTH: u32 = 200;
 
 impl PoolConfig {
     /// Validate pool configuration according to Nevo invariants.

--- a/contract/contract/src/interfaces/mod.rs
+++ b/contract/contract/src/interfaces/mod.rs
@@ -1,1 +1,2 @@
 pub mod crowdfunding;
+pub mod second_crowdfunding;

--- a/contract/contract/src/interfaces/second_crowdfunding.rs
+++ b/contract/contract/src/interfaces/second_crowdfunding.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{Address, BytesN, Env, String};
+
+use crate::base::errors::SecondCrowdfundingError;
+
+/// A focused trait for `create_campaign` that surfaces string-validation
+/// errors directly as [`SecondCrowdfundingError`] without remapping them to
+/// the broader [`crate::base::errors::CrowdfundingError`] enum.
+///
+/// Use this trait (and its implementation on [`crate::crowdfunding::CrowdfundingContract`])
+/// when you need to distinguish string-length violations from other contract
+/// errors — for example, in unit-tests that verify title/metadata length
+/// limits without going through the Soroban client dispatcher.
+pub trait SecondCrowdfundingTrait {
+    /// Validates the campaign title length and, if valid, creates the campaign.
+    ///
+    /// Returns [`SecondCrowdfundingError::StringTooLong`] when `title` exceeds
+    /// the maximum allowed length (200 characters).  All other errors are
+    /// outside the scope of this trait.
+    fn create_campaign_checked(
+        env: Env,
+        id: BytesN<32>,
+        title: String,
+        creator: Address,
+        goal: i128,
+        deadline: u64,
+        token_address: Address,
+    ) -> Result<(), SecondCrowdfundingError>;
+}

--- a/contract/contract/test/mod.rs
+++ b/contract/contract/test/mod.rs
@@ -8,4 +8,5 @@ mod platform_fee_test;
 mod pool_remaining_time_test;
 mod renounce_admin_test;
 // mod update_pool_metadata_test; // Features not yet implemented
+mod validate_string_length_test;
 mod verify_cause;

--- a/contract/contract/test/validate_string_length_test.rs
+++ b/contract/contract/test/validate_string_length_test.rs
@@ -1,0 +1,130 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+use crate::{
+    base::errors::{CrowdfundingError, SecondCrowdfundingError},
+    crowdfunding::{CrowdfundingContract, CrowdfundingContractClient},
+    interfaces::second_crowdfunding::SecondCrowdfundingTrait,
+};
+
+fn setup(env: &Env) -> (CrowdfundingContractClient<'_>, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, CrowdfundingContract);
+    let client = CrowdfundingContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let token = Address::generate(env);
+    client.initialize(&admin, &token, &0);
+
+    (client, token)
+}
+
+fn string_of_len(env: &Env, len: usize) -> String {
+    String::from_str(env, &"a".repeat(len))
+}
+
+// ── create_campaign ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_campaign_title_within_limit_succeeds() {
+    let env = Env::default();
+    let (client, token) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let campaign_id = BytesN::from_array(&env, &[1u8; 32]);
+    let title = string_of_len(&env, 200); // exactly at the limit
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    // Via Soroban client: string validation maps to CrowdfundingError::InvalidTitle
+    let result =
+        client.try_create_campaign(&campaign_id, &title, &creator, &1000, &deadline, &token);
+    assert!(result.is_ok(), "title of 200 chars should be accepted");
+
+    // Via SecondCrowdfundingTrait directly: validates string length only
+    let trait_result = <CrowdfundingContract as SecondCrowdfundingTrait>::create_campaign_checked(
+        env.clone(),
+        campaign_id,
+        title,
+        creator,
+        1000,
+        deadline,
+        token,
+    );
+    assert!(
+        trait_result.is_ok(),
+        "SecondCrowdfundingTrait: title of 200 chars should be accepted"
+    );
+}
+
+#[test]
+fn test_campaign_title_exceeds_limit_returns_error() {
+    let env = Env::default();
+    let (client, token) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let campaign_id = BytesN::from_array(&env, &[2u8; 32]);
+    let title = string_of_len(&env, 201); // one over the limit
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    // Via Soroban client: SecondCrowdfundingError is mapped to CrowdfundingError::InvalidTitle
+    let client_result =
+        client.try_create_campaign(&campaign_id, &title, &creator, &1000, &deadline, &token);
+    assert_eq!(
+        client_result,
+        Err(Ok(CrowdfundingError::InvalidTitle)),
+        "title of 201 chars should return CrowdfundingError::InvalidTitle via client"
+    );
+
+    // Via SecondCrowdfundingTrait directly: returns StringTooLong without remapping
+    let trait_result = <CrowdfundingContract as SecondCrowdfundingTrait>::create_campaign_checked(
+        env.clone(),
+        campaign_id,
+        title,
+        creator,
+        1000,
+        deadline,
+        token,
+    );
+    assert_eq!(
+        trait_result,
+        Err(SecondCrowdfundingError::StringTooLong),
+        "title of 201 chars should return StringTooLong via SecondCrowdfundingTrait"
+    );
+}
+
+#[test]
+fn test_campaign_title_much_longer_than_limit_returns_error() {
+    let env = Env::default();
+    let (client, token) = setup(&env);
+
+    let creator = Address::generate(&env);
+    let campaign_id = BytesN::from_array(&env, &[3u8; 32]);
+    let title = string_of_len(&env, 500); // well over the limit
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    // Via Soroban client: SecondCrowdfundingError is mapped to CrowdfundingError::InvalidTitle
+    let client_result =
+        client.try_create_campaign(&campaign_id, &title, &creator, &1000, &deadline, &token);
+    assert_eq!(
+        client_result,
+        Err(Ok(CrowdfundingError::InvalidTitle)),
+        "title of 500 chars should return CrowdfundingError::InvalidTitle via client"
+    );
+
+    // Via SecondCrowdfundingTrait directly: returns StringTooLong without remapping
+    let trait_result = <CrowdfundingContract as SecondCrowdfundingTrait>::create_campaign_checked(
+        env.clone(),
+        campaign_id,
+        title,
+        creator,
+        1000,
+        deadline,
+        token,
+    );
+    assert_eq!(
+        trait_result,
+        Err(SecondCrowdfundingError::StringTooLong),
+        "title of 500 chars should return StringTooLong via SecondCrowdfundingTrait"
+    );
+}


### PR DESCRIPTION
This PR adds a helper function that is used to verify and returns and error for length of strings that are 200 (character length) long.

Closes #96 