### PR TITLE
feat: add AppApprv and AppRej Stellar events to approval layer

### DIFF
--- a/contract/contract/src/base/events.rs
+++ b/contract/contract/src/base/events.rs
@@ -1,5 +1,5 @@
 #![allow(deprecated)]
-use soroban_sdk::{Address, BytesN, Env, String, Symbol};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Symbol};
 
 use crate::base::types::PoolState;
 
@@ -187,4 +187,14 @@ pub fn ticket_sold(
     let topics = (Symbol::new(env, "ticket_sold"), pool_id, buyer);
     env.events()
         .publish(topics, (price, event_amount, fee_amount));
+}
+
+pub fn application_approved(env: &Env, admin: Address, cause: Address) {
+    let topics = (symbol_short!("AppApprv"), admin);
+    env.events().publish(topics, cause);
+}
+
+pub fn application_rejected(env: &Env, admin: Address, cause: Address) {
+    let topics = (symbol_short!("AppRej"), admin);
+    env.events().publish(topics, cause);
 }

--- a/contract/contract/src/crowdfunding.rs
+++ b/contract/contract/src/crowdfunding.rs
@@ -1703,7 +1703,8 @@ impl CrowdfundingTrait for CrowdfundingContract {
 
         env.storage()
             .instance()
-            .set(&StorageKey::VerifiedCause(cause), &true);
+            .set(&StorageKey::VerifiedCause(cause.clone()), &true);
+        events::application_approved(&env, admin, cause);
         Ok(())
     }
 
@@ -1712,6 +1713,21 @@ impl CrowdfundingTrait for CrowdfundingContract {
             .instance()
             .get(&StorageKey::VerifiedCause(cause))
             .unwrap_or(false)
+    }
+
+    fn reject_cause(env: Env, cause: Address) -> Result<(), CrowdfundingError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&StorageKey::Admin)
+            .ok_or(CrowdfundingError::NotInitialized)?;
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .remove(&StorageKey::VerifiedCause(cause.clone()));
+        events::application_rejected(&env, admin, cause);
+        Ok(())
     }
 
     fn withdraw_platform_fees(

--- a/contract/contract/src/interfaces/crowdfunding.rs
+++ b/contract/contract/src/interfaces/crowdfunding.rs
@@ -172,6 +172,8 @@ pub trait CrowdfundingTrait {
 
     fn is_cause_verified(env: Env, cause: Address) -> bool;
 
+    fn reject_cause(env: Env, cause: Address) -> Result<(), CrowdfundingError>;
+
     fn withdraw_platform_fees(env: Env, to: Address, amount: i128)
         -> Result<(), CrowdfundingError>;
 

--- a/contract/contract/test/verify_cause.rs
+++ b/contract/contract/test/verify_cause.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env, IntoVal};
+use soroban_sdk::{symbol_short, testutils::Address as _, testutils::Events, Address, Env, IntoVal};
 
 use crate::crowdfunding::{CrowdfundingContract, CrowdfundingContractClient};
 
@@ -10,6 +10,13 @@ fn create_client() -> (Env, CrowdfundingContractClient<'static>) {
     let contract_id = env.register(CrowdfundingContract, ());
     let client = CrowdfundingContractClient::new(&env, &contract_id);
     (env, client)
+}
+
+fn setup(env: &Env, client: &CrowdfundingContractClient) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let token = Address::generate(env);
+    client.initialize(&admin, &token, &1000);
+    (admin, token)
 }
 
 #[test]
@@ -67,4 +74,78 @@ fn test_verify_cause_not_initialized() {
 
     // Should panic with NotInitialized
     client.verify_cause(&cause);
+}
+
+#[test]
+fn test_verify_cause_emits_app_apprv_event() {
+    let (env, client) = create_client();
+    let (_, _) = setup(&env, &client);
+    let cause = Address::generate(&env);
+
+    client.verify_cause(&cause);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, data)| {
+        if topics.is_empty() {
+            return false;
+        }
+        use soroban_sdk::FromVal;
+        let sym = soroban_sdk::Symbol::from_val(&env, &topics.get(0).unwrap());
+        if sym != symbol_short!("AppApprv") {
+            return false;
+        }
+        let emitted_cause = Address::from_val(&env, &data);
+        emitted_cause == cause
+    });
+    assert!(found, "AppApprv event not emitted by verify_cause");
+}
+
+#[test]
+fn test_reject_cause_removes_verification_and_emits_event() {
+    let (env, client) = create_client();
+    let (_, _) = setup(&env, &client);
+    let cause = Address::generate(&env);
+
+    client.verify_cause(&cause);
+    assert!(client.is_cause_verified(&cause));
+
+    client.reject_cause(&cause);
+    assert!(!client.is_cause_verified(&cause));
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, data)| {
+        if topics.is_empty() {
+            return false;
+        }
+        use soroban_sdk::FromVal;
+        let sym = soroban_sdk::Symbol::from_val(&env, &topics.get(0).unwrap());
+        if sym != symbol_short!("AppRej") {
+            return false;
+        }
+        let emitted_cause = Address::from_val(&env, &data);
+        emitted_cause == cause
+    });
+    assert!(found, "AppRej event not emitted by reject_cause");
+}
+
+#[test]
+fn test_reject_cause_on_unverified_address_emits_event() {
+    let (env, client) = create_client();
+    let (_, _) = setup(&env, &client);
+    let cause = Address::generate(&env);
+
+    // reject without prior verify — should still fire the event
+    client.reject_cause(&cause);
+    assert!(!client.is_cause_verified(&cause));
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        if topics.is_empty() {
+            return false;
+        }
+        use soroban_sdk::FromVal;
+        let sym = soroban_sdk::Symbol::from_val(&env, &topics.get(0).unwrap());
+        sym == symbol_short!("AppRej")
+    });
+    assert!(found, "AppRej event not emitted on unverified reject");
 }


### PR DESCRIPTION
## Summary

Adds Stellar events to the approval layer so state changes in `verify_cause` and `reject_cause` communicate outwards through the ledger.

## Changes

- `src/base/events.rs` — added `application_approved` (`symbol_short!("AppApprv")`) and `application_rejected` (`symbol_short!("AppRej")`) event functions
- `src/crowdfunding.rs` — `verify_cause` fires `AppApprv` after storage write; new `reject_cause` removes verification and fires `AppRej`
- `src/interfaces/crowdfunding.rs` — added `reject_cause` to `CrowdfundingTrait`
- `test/verify_cause.rs` — 3 new tests covering both events

## Acceptance Criteria

- [x] `symbol_short!("AppApprv")` and `symbol_short!("AppRej")` used as topics
- [x] Events fired natively post-storage writes
- [x] Event signatures represent actions cleanly
- [x] Tests added and passing

closes #300 