### PR TITLE
feat(FundEdu): define custom errors (errors.rs) [#280]

### DIFF
--- a/FundEdu/Cargo.toml
+++ b/FundEdu/Cargo.toml
@@ -1,0 +1,32 @@
+[workspace]
+resolver = "2"
+members = [".", ]
+
+[workspace.dependencies]
+soroban-sdk = "23.4.1"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[package]
+name = "fund-edu"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/FundEdu/src/errors.rs
+++ b/FundEdu/src/errors.rs
@@ -1,0 +1,48 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum FundEduError {
+    // Pool errors
+    InvalidSponsor = 1,
+    PoolNotActive = 2,
+    // Application errors
+    DuplicateApplication = 3,
+    UnauthorizedValidator = 4,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FundEduError;
+
+    #[test]
+    fn discriminants_are_correct() {
+        assert_eq!(FundEduError::InvalidSponsor as u32, 1);
+        assert_eq!(FundEduError::PoolNotActive as u32, 2);
+        assert_eq!(FundEduError::DuplicateApplication as u32, 3);
+        assert_eq!(FundEduError::UnauthorizedValidator as u32, 4);
+    }
+
+    #[test]
+    fn discriminants_are_distinct() {
+        let variants = [
+            FundEduError::InvalidSponsor,
+            FundEduError::PoolNotActive,
+            FundEduError::DuplicateApplication,
+            FundEduError::UnauthorizedValidator,
+        ];
+        for i in 0..variants.len() {
+            for j in (i + 1)..variants.len() {
+                assert_ne!(variants[i], variants[j]);
+            }
+        }
+    }
+
+    #[test]
+    fn ordering_follows_discriminant() {
+        assert!(FundEduError::InvalidSponsor < FundEduError::PoolNotActive);
+        assert!(FundEduError::PoolNotActive < FundEduError::DuplicateApplication);
+        assert!(FundEduError::DuplicateApplication < FundEduError::UnauthorizedValidator);
+    }
+}

--- a/FundEdu/src/lib.rs
+++ b/FundEdu/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod errors;


### PR DESCRIPTION
## Summary

Scaffolds the `FundEdu` crate and implements the centralized `FundEduError` enum as required by issue #280.

## Changes

- `FundEdu/Cargo.toml` — standalone workspace crate pinned to `soroban-sdk = "23.4.1"`
- `FundEdu/src/lib.rs` — `#![no_std]` crate root
- `FundEdu/src/errors.rs` — `FundEduError` contracterror enum:

| Code | Variant | Category |
|------|---------|----------|
| 1 | `InvalidSponsor` | Pool |
| 2 | `PoolNotActive` | Pool |
| 3 | `DuplicateApplication` | Application |
| 4 | `UnauthorizedValidator` | Application |

## Tests

Three unit tests in `errors.rs`:
- `discriminants_are_correct` — verifies each variant maps to its expected `u32` value
- `discriminants_are_distinct` — asserts no two variants are equal
- `ordering_follows_discriminant` — verifies `PartialOrd` ordering

Closes #280