### PR TITLE
Add Event Emission for Pool Lifecycle

### DIFF
--- a/contract/contract/src/base/events.rs
+++ b/contract/contract/src/base/events.rs
@@ -1,5 +1,5 @@
 #![allow(deprecated)]
-use soroban_sdk::{Address, BytesN, Env, String, Symbol};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Symbol};
 
 use crate::base::types::PoolState;
 
@@ -27,8 +27,23 @@ pub fn pool_created(
     creator: Address,
     details: (String, String, i128, i128, u64),
 ) {
-    let topics = (Symbol::new(env, "pool_created"), pool_id, creator);
+    let topics = (symbol_short!("PoolCre"), pool_id, creator);
     env.events().publish(topics, details);
+}
+
+pub fn pool_metadata_updated_v2(
+    env: &Env,
+    pool_id: u64,
+    updater: Address,
+    new_metadata_hash: String,
+) {
+    let topics = (symbol_short!("PoolUpd"), pool_id, updater);
+    env.events().publish(topics, new_metadata_hash);
+}
+
+pub fn pool_paused(env: &Env, pool_id: u64) {
+    let topics = (symbol_short!("PoolPau"), pool_id);
+    env.events().publish(topics, ());
 }
 
 pub fn event_created(
@@ -170,6 +185,7 @@ pub fn pool_metadata_updated(env: &Env, pool_id: u64, updater: Address, new_meta
     let topics = (Symbol::new(env, "pool_metadata_updated"), pool_id, updater);
     env.events().publish(topics, new_metadata_hash);
 }
+
 
 pub fn platform_fee_bps_set(env: &Env, admin: Address, fee_bps: u32) {
     let topics = (Symbol::new(env, "platform_fee_bps_set"), admin);

--- a/contract/contract/src/crowdfunding.rs
+++ b/contract/contract/src/crowdfunding.rs
@@ -1133,6 +1133,57 @@ impl CrowdfundingTrait for CrowdfundingContract {
         }
     }
 
+    fn update_pool_metadata_hash(
+        env: Env,
+        pool_id: u64,
+        caller: Address,
+        new_hash: String,
+    ) -> Result<(), CrowdfundingError> {
+        if Self::is_paused(env.clone()) {
+            return Err(CrowdfundingError::ContractPaused);
+        }
+
+        let pool_key = StorageKey::Pool(pool_id);
+        if !env.storage().instance().has(&pool_key) {
+            return Err(CrowdfundingError::PoolNotFound);
+        }
+
+        let creator_key = StorageKey::PoolCreator(pool_id);
+        let creator: Address = env
+            .storage()
+            .instance()
+            .get(&creator_key)
+            .ok_or(CrowdfundingError::Unauthorized)?;
+
+        if caller != creator {
+            return Err(CrowdfundingError::Unauthorized);
+        }
+        caller.require_auth();
+
+        if new_hash.len() > MAX_HASH_LENGTH {
+            return Err(CrowdfundingError::InvalidMetadata);
+        }
+
+        let metadata_key = StorageKey::PoolMetadata(pool_id);
+        let mut metadata: PoolMetadata = env
+            .storage()
+            .persistent()
+            .get(&metadata_key)
+            .unwrap_or(PoolMetadata {
+                description: String::from_str(&env, ""),
+                external_url: String::from_str(&env, ""),
+                image_hash: String::from_str(&env, ""),
+            });
+
+        metadata.image_hash = new_hash.clone();
+        env.storage().persistent().set(&metadata_key, &metadata);
+
+        events::pool_metadata_updated(&env, pool_id, caller.clone(), new_hash.clone());
+        events::pool_metadata_updated_v2(&env, pool_id, caller, new_hash);
+
+        Ok(())
+    }
+
     fn update_pool_state(
         env: Env,
         pool_id: u64,
@@ -1166,8 +1217,11 @@ impl CrowdfundingTrait for CrowdfundingContract {
         // Update state
         env.storage().instance().set(&state_key, &new_state);
 
-        // Emit event
-        events::pool_state_updated(&env, pool_id, new_state);
+        // Emit events
+        events::pool_state_updated(&env, pool_id, new_state.clone());
+        if new_state == PoolState::Paused {
+            events::pool_paused(&env, pool_id);
+        }
 
         Ok(())
     }

--- a/contract/contract/src/interfaces/crowdfunding.rs
+++ b/contract/contract/src/interfaces/crowdfunding.rs
@@ -108,6 +108,13 @@ pub trait CrowdfundingTrait {
 
     fn get_pool_metadata(env: Env, pool_id: u64) -> (String, String, String);
 
+    fn update_pool_metadata_hash(
+        env: Env,
+        pool_id: u64,
+        caller: Address,
+        new_hash: String,
+    ) -> Result<(), CrowdfundingError>;
+
     fn update_pool_state(
         env: Env,
         pool_id: u64,

--- a/contract/contract/test/mod.rs
+++ b/contract/contract/test/mod.rs
@@ -8,10 +8,11 @@ mod create_pool;
 mod crowdfunding_test;
 mod get_pool_contributions_paginated_test;
 mod platform_fee_test;
+mod pool_lifecycle_events_test;
 mod pool_remaining_time_test;
 mod renounce_admin_test;
 mod set_platform_fee_bps_test;
-// mod update_pool_metadata_test; // Features not yet implemented
+mod update_pool_metadata_test;
 mod upgrade_contract_test;
 mod validate_string_length_test;
 mod verify_cause;

--- a/contract/contract/test/pool_lifecycle_events_test.rs
+++ b/contract/contract/test/pool_lifecycle_events_test.rs
@@ -1,0 +1,261 @@
+#![cfg(test)]
+
+use crate::{
+    base::types::{PoolConfig, PoolState},
+    crowdfunding::{CrowdfundingContract, CrowdfundingContractClient},
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events},
+    Address, Env, String, Symbol,
+};
+
+fn setup(env: &Env) -> (CrowdfundingContractClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(CrowdfundingContract, ());
+    let client = CrowdfundingContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &token, &0);
+    (client, admin, token)
+}
+
+fn make_pool_config(env: &Env, token: &Address) -> PoolConfig {
+    PoolConfig {
+        name: String::from_str(env, "Lifecycle Pool"),
+        description: String::from_str(env, "Testing pool lifecycle events"),
+        target_amount: 10_000,
+        min_contribution: 0,
+        is_private: false,
+        duration: 86_400,
+        created_at: env.ledger().timestamp(),
+        token_address: token.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PoolCre — emitted by create_pool
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pool_cre_event_emitted_on_create_pool() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    client.create_pool(&creator, &make_pool_config(&env, &token));
+
+    let pool_cre = symbol_short!("PoolCre");
+    let found = env.events().all().iter().any(|(_, topics, _)| {
+        !topics.is_empty() && {
+            use soroban_sdk::FromVal;
+            Symbol::from_val(&env, &topics.get(0).unwrap()) == pool_cre
+        }
+    });
+
+    assert!(found, "PoolCre event must be emitted by create_pool");
+}
+
+#[test]
+fn test_pool_cre_event_contains_pool_id_and_creator() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(&creator, &make_pool_config(&env, &token));
+
+    let pool_cre = symbol_short!("PoolCre");
+    let found = env.events().all().iter().any(|(_, topics, _)| {
+        if topics.len() < 3 {
+            return false;
+        }
+        use soroban_sdk::FromVal;
+        let sym = Symbol::from_val(&env, &topics.get(0).unwrap());
+        if sym != pool_cre {
+            return false;
+        }
+        let id = u64::from_val(&env, &topics.get(1).unwrap());
+        let addr = Address::from_val(&env, &topics.get(2).unwrap());
+        id == pool_id && addr == creator
+    });
+
+    assert!(
+        found,
+        "PoolCre topics must include pool_id and creator address"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PoolUpd — emitted by update_pool_metadata_hash
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pool_upd_event_emitted_on_metadata_update() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(&creator, &make_pool_config(&env, &token));
+    let new_hash = String::from_str(&env, "QmTestHash42");
+
+    client.update_pool_metadata_hash(&pool_id, &creator, &new_hash);
+
+    let pool_upd = symbol_short!("PoolUpd");
+    let found = env.events().all().iter().any(|(_, topics, _)| {
+        !topics.is_empty() && {
+            use soroban_sdk::FromVal;
+            Symbol::from_val(&env, &topics.get(0).unwrap()) == pool_upd
+        }
+    });
+
+    assert!(
+        found,
+        "PoolUpd event must be emitted by update_pool_metadata_hash"
+    );
+}
+
+#[test]
+fn test_pool_upd_event_payload_contains_new_hash() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(&creator, &make_pool_config(&env, &token));
+    let new_hash = String::from_str(&env, "QmPayloadHash99");
+
+    client.update_pool_metadata_hash(&pool_id, &creator, &new_hash);
+
+    let pool_upd = symbol_short!("PoolUpd");
+    let found = env.events().all().iter().any(|(_, topics, data)| {
+        if topics.is_empty() {
+            return false;
+        }
+        use soroban_sdk::{FromVal, TryFromVal};
+        let sym = Symbol::from_val(&env, &topics.get(0).unwrap());
+        if sym != pool_upd {
+            return false;
+        }
+        matches!(String::try_from_val(&env, &data), Ok(h) if h == new_hash)
+    });
+
+    assert!(
+        found,
+        "PoolUpd event payload must contain the new metadata hash"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PoolPau — emitted by update_pool_state when transitioning to Paused
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pool_pau_event_emitted_when_pool_paused() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(&creator, &make_pool_config(&env, &token));
+    client.update_pool_state(&pool_id, &PoolState::Paused);
+
+    let pool_pau = symbol_short!("PoolPau");
+    let found = env.events().all().iter().any(|(_, topics, _)| {
+        !topics.is_empty() && {
+            use soroban_sdk::FromVal;
+            Symbol::from_val(&env, &topics.get(0).unwrap()) == pool_pau
+        }
+    });
+
+    assert!(
+        found,
+        "PoolPau event must be emitted when pool transitions to Paused"
+    );
+}
+
+#[test]
+fn test_pool_pau_not_emitted_for_non_pause_transitions() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(&creator, &make_pool_config(&env, &token));
+    // Transition to Completed — must NOT emit PoolPau
+    client.update_pool_state(&pool_id, &PoolState::Completed);
+
+    let pool_pau = symbol_short!("PoolPau");
+    let found = env.events().all().iter().any(|(_, topics, _)| {
+        !topics.is_empty() && {
+            use soroban_sdk::FromVal;
+            Symbol::from_val(&env, &topics.get(0).unwrap()) == pool_pau
+        }
+    });
+
+    assert!(
+        !found,
+        "PoolPau must NOT be emitted for non-Paused state transitions"
+    );
+}
+
+#[test]
+fn test_pool_pau_topic_contains_pool_id() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(&creator, &make_pool_config(&env, &token));
+    client.update_pool_state(&pool_id, &PoolState::Paused);
+
+    let pool_pau = symbol_short!("PoolPau");
+    let found = env.events().all().iter().any(|(_, topics, _)| {
+        if topics.len() < 2 {
+            return false;
+        }
+        use soroban_sdk::FromVal;
+        let sym = Symbol::from_val(&env, &topics.get(0).unwrap());
+        if sym != pool_pau {
+            return false;
+        }
+        u64::from_val(&env, &topics.get(1).unwrap()) == pool_id
+    });
+
+    assert!(
+        found,
+        "PoolPau topic must include the pool_id for indexing"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// State accuracy — events reflect the actual updated state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pool_state_updated_event_reflects_accurate_state() {
+    let env = Env::default();
+    let (client, _, token) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let pool_id = client.create_pool(&creator, &make_pool_config(&env, &token));
+    client.update_pool_state(&pool_id, &PoolState::Paused);
+
+    let state_updated = Symbol::new(&env, "pool_state_updated");
+    let found = env.events().all().iter().any(|(_, topics, data)| {
+        if topics.is_empty() {
+            return false;
+        }
+        use soroban_sdk::{FromVal, TryFromVal};
+        let sym = Symbol::from_val(&env, &topics.get(0).unwrap());
+        if sym != state_updated {
+            return false;
+        }
+        matches!(PoolState::try_from_val(&env, &data), Ok(PoolState::Paused))
+    });
+
+    assert!(
+        found,
+        "pool_state_updated event payload must accurately reflect the new Paused state"
+    );
+}

--- a/contract/contract/test/update_pool_metadata_test.rs
+++ b/contract/contract/test/update_pool_metadata_test.rs
@@ -27,7 +27,7 @@ fn setup_test(env: &Env) -> (CrowdfundingContractClient<'_>, Address, Address) {
     (client, admin, token_id)
 }
 
-fn create_test_pool(env: &Env, client: &CrowdfundingContractClient<'_>, creator: &Address) -> u64 {
+fn create_test_pool(env: &Env, client: &CrowdfundingContractClient<'_>, creator: &Address, token_id: &Address) -> u64 {
     env.ledger().with_mut(|li| li.timestamp = 1_000);
 
     let config = PoolConfig {
@@ -38,6 +38,7 @@ fn create_test_pool(env: &Env, client: &CrowdfundingContractClient<'_>, creator:
         is_private: false,
         duration: 86400, // 1 day
         created_at: 1_000,
+        token_address: token_id.clone(),
     };
 
     client.create_pool(creator, &config)
@@ -49,7 +50,7 @@ fn test_update_pool_metadata_hash_success() {
     let (client, _admin, _token_id) = setup_test(&env);
 
     let creator = Address::generate(&env);
-    let pool_id = create_test_pool(&env, &client, &creator);
+    let pool_id = create_test_pool(&env, &client, &creator, &_token_id);
 
     let new_hash = String::from_str(&env, "QmNewHash123456789");
 
@@ -68,7 +69,7 @@ fn test_update_pool_metadata_hash_only_creator_can_update() {
 
     let creator = Address::generate(&env);
     let non_creator = Address::generate(&env);
-    let pool_id = create_test_pool(&env, &client, &creator);
+    let pool_id = create_test_pool(&env, &client, &creator, &_token_id);
 
     let new_hash = String::from_str(&env, "QmNewHash123456789");
 
@@ -103,7 +104,7 @@ fn test_update_pool_metadata_hash_too_long() {
     let (client, _admin, _token_id) = setup_test(&env);
 
     let creator = Address::generate(&env);
-    let pool_id = create_test_pool(&env, &client, &creator);
+    let pool_id = create_test_pool(&env, &client, &creator, &_token_id);
 
     // Create a hash that exceeds MAX_HASH_LENGTH (100 characters)
     let long_hash = String::from_str(
@@ -125,7 +126,7 @@ fn test_update_pool_metadata_hash_when_paused() {
     let (client, _admin, _token_id) = setup_test(&env);
 
     let creator = Address::generate(&env);
-    let pool_id = create_test_pool(&env, &client, &creator);
+    let pool_id = create_test_pool(&env, &client, &creator, &_token_id);
 
     // Pause the contract
     client.pause();
@@ -146,7 +147,7 @@ fn test_update_pool_metadata_hash_multiple_times() {
     let (client, _admin, _token_id) = setup_test(&env);
 
     let creator = Address::generate(&env);
-    let pool_id = create_test_pool(&env, &client, &creator);
+    let pool_id = create_test_pool(&env, &client, &creator, &_token_id);
 
     // First update
     let hash1 = String::from_str(&env, "QmFirstHash");
@@ -171,7 +172,7 @@ fn test_update_pool_metadata_hash_event_emission() {
     let (client, _admin, _token_id) = setup_test(&env);
 
     let creator = Address::generate(&env);
-    let pool_id = create_test_pool(&env, &client, &creator);
+    let pool_id = create_test_pool(&env, &client, &creator, &_token_id);
 
     let new_hash = String::from_str(&env, "QmNewHash123456789");
 


### PR DESCRIPTION
closes #288 


This PR introduces event emission for key pool lifecycle actions to improve transparency and enable external tracking via Stellar Horizon and other services. Events are emitted for pool creation, updates, and pause actions, ensuring state changes are observable and verifiable.

Changes:
Added event emission using env.events().publish for:
Pool creation (PoolCre)
Pool updates
Pool pause actions
Structured event payloads to include relevant pool state data
Ensured events are emitted at the end of lifecycle operations