### PR TITLE
feat: implement reject_application in FundEdu contract

### DIFF
--- a/FundEdu/Cargo.toml
+++ b/FundEdu/Cargo.toml
@@ -1,0 +1,32 @@
+[workspace]
+resolver = "2"
+members = [".", ]
+
+[workspace.dependencies]
+soroban-sdk = "23.4.1"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[package]
+name = "fund-edu"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/FundEdu/src/errors.rs
+++ b/FundEdu/src/errors.rs
@@ -1,0 +1,48 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum FundEduError {
+    // Pool errors
+    InvalidSponsor = 1,
+    PoolNotActive = 2,
+    // Application errors
+    DuplicateApplication = 3,
+    UnauthorizedValidator = 4,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FundEduError;
+
+    #[test]
+    fn discriminants_are_correct() {
+        assert_eq!(FundEduError::InvalidSponsor as u32, 1);
+        assert_eq!(FundEduError::PoolNotActive as u32, 2);
+        assert_eq!(FundEduError::DuplicateApplication as u32, 3);
+        assert_eq!(FundEduError::UnauthorizedValidator as u32, 4);
+    }
+
+    #[test]
+    fn discriminants_are_distinct() {
+        let variants = [
+            FundEduError::InvalidSponsor,
+            FundEduError::PoolNotActive,
+            FundEduError::DuplicateApplication,
+            FundEduError::UnauthorizedValidator,
+        ];
+        for i in 0..variants.len() {
+            for j in (i + 1)..variants.len() {
+                assert_ne!(variants[i], variants[j]);
+            }
+        }
+    }
+
+    #[test]
+    fn ordering_follows_discriminant() {
+        assert!(FundEduError::InvalidSponsor < FundEduError::PoolNotActive);
+        assert!(FundEduError::PoolNotActive < FundEduError::DuplicateApplication);
+        assert!(FundEduError::DuplicateApplication < FundEduError::UnauthorizedValidator);
+    }
+}

--- a/FundEdu/src/errors.rs
+++ b/FundEdu/src/errors.rs
@@ -10,6 +10,8 @@ pub enum FundEduError {
     // Application errors
     DuplicateApplication = 3,
     UnauthorizedValidator = 4,
+    NotPending = 5,
+    AlreadyRejected = 6,
 }
 
 #[cfg(test)]
@@ -22,6 +24,8 @@ mod tests {
         assert_eq!(FundEduError::PoolNotActive as u32, 2);
         assert_eq!(FundEduError::DuplicateApplication as u32, 3);
         assert_eq!(FundEduError::UnauthorizedValidator as u32, 4);
+        assert_eq!(FundEduError::NotPending as u32, 5);
+        assert_eq!(FundEduError::AlreadyRejected as u32, 6);
     }
 
     #[test]
@@ -31,6 +35,8 @@ mod tests {
             FundEduError::PoolNotActive,
             FundEduError::DuplicateApplication,
             FundEduError::UnauthorizedValidator,
+            FundEduError::NotPending,
+            FundEduError::AlreadyRejected,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {
@@ -44,5 +50,7 @@ mod tests {
         assert!(FundEduError::InvalidSponsor < FundEduError::PoolNotActive);
         assert!(FundEduError::PoolNotActive < FundEduError::DuplicateApplication);
         assert!(FundEduError::DuplicateApplication < FundEduError::UnauthorizedValidator);
+        assert!(FundEduError::UnauthorizedValidator < FundEduError::NotPending);
+        assert!(FundEduError::NotPending < FundEduError::AlreadyRejected);
     }
 }

--- a/FundEdu/src/lib.rs
+++ b/FundEdu/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod errors;

--- a/FundEdu/src/lib.rs
+++ b/FundEdu/src/lib.rs
@@ -1,3 +1,182 @@
 #![no_std]
 
 pub mod errors;
+
+use errors::FundEduError;
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+/// On-chain status of a student application.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ApplicationStatus {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+/// Storage key scoped to a (validator, applicant) pair.
+#[contracttype]
+pub enum ApplicationKey {
+    Application(Address, Address),
+}
+
+#[contract]
+pub struct FundEduContract;
+
+#[contractimpl]
+impl FundEduContract {
+    /// Approve a pending application.
+    ///
+    /// Requires `validator` auth. Returns `NotPending` if the application is
+    /// not currently `Pending`.
+    pub fn approve_application(
+        env: Env,
+        validator: Address,
+        applicant: Address,
+    ) -> Result<(), FundEduError> {
+        validator.require_auth();
+
+        let key = ApplicationKey::Application(validator.clone(), applicant.clone());
+        let status: ApplicationStatus = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(ApplicationStatus::Pending);
+
+        if status != ApplicationStatus::Pending {
+            return Err(FundEduError::NotPending);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&key, &ApplicationStatus::Approved);
+        Ok(())
+    }
+
+    /// Reject a pending application.
+    ///
+    /// Requires `validator` auth. Returns `NotPending` if the application is
+    /// not currently `Pending`.
+    pub fn reject_application(
+        env: Env,
+        validator: Address,
+        applicant: Address,
+    ) -> Result<(), FundEduError> {
+        validator.require_auth();
+
+        let key = ApplicationKey::Application(validator.clone(), applicant.clone());
+        let status: ApplicationStatus = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(ApplicationStatus::Pending);
+
+        if status != ApplicationStatus::Pending {
+            return Err(FundEduError::NotPending);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&key, &ApplicationStatus::Rejected);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn setup() -> (Env, FundEduContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(FundEduContract, ());
+        let client = FundEduContractClient::new(&env, &contract_id);
+        let validator = Address::generate(&env);
+        let applicant = Address::generate(&env);
+        (env, client, validator, applicant)
+    }
+
+    // ── approve_application ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_approve_pending_succeeds() {
+        let (_env, client, validator, applicant) = setup();
+        client.approve_application(&validator, &applicant);
+    }
+
+    #[test]
+    fn test_approve_already_approved_returns_not_pending() {
+        let (_env, client, validator, applicant) = setup();
+        client.approve_application(&validator, &applicant);
+        let err = client
+            .try_approve_application(&validator, &applicant)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, FundEduError::NotPending);
+    }
+
+    #[test]
+    fn test_approve_already_rejected_returns_not_pending() {
+        let (_env, client, validator, applicant) = setup();
+        client.reject_application(&validator, &applicant);
+        let err = client
+            .try_approve_application(&validator, &applicant)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, FundEduError::NotPending);
+    }
+
+    // ── reject_application ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_reject_pending_succeeds() {
+        let (_env, client, validator, applicant) = setup();
+        client.reject_application(&validator, &applicant);
+    }
+
+    #[test]
+    fn test_reject_already_approved_returns_not_pending() {
+        let (_env, client, validator, applicant) = setup();
+        client.approve_application(&validator, &applicant);
+        let err = client
+            .try_reject_application(&validator, &applicant)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, FundEduError::NotPending);
+    }
+
+    #[test]
+    fn test_reject_already_rejected_returns_not_pending() {
+        let (_env, client, validator, applicant) = setup();
+        client.reject_application(&validator, &applicant);
+        let err = client
+            .try_reject_application(&validator, &applicant)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, FundEduError::NotPending);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_reject_unauthorized_panics() {
+        let env = Env::default();
+        // No mock_all_auths — auth will fail
+        let contract_id = env.register(FundEduContract, ());
+        let client = FundEduContractClient::new(&env, &contract_id);
+        let validator = Address::generate(&env);
+        let applicant = Address::generate(&env);
+        client.reject_application(&validator, &applicant);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Auth, InvalidAction)")]
+    fn test_approve_unauthorized_panics() {
+        let env = Env::default();
+        let contract_id = env.register(FundEduContract, ());
+        let client = FundEduContractClient::new(&env, &contract_id);
+        let validator = Address::generate(&env);
+        let applicant = Address::generate(&env);
+        client.approve_application(&validator, &applicant);
+    }
+}


### PR DESCRIPTION
Closes #280

---

## Summary

Implements `reject_application` (and `approve_application`) in the `FundEdu` crate as required by #299.

## Changes

- **`FundEdu/src/lib.rs`**: Full Soroban contract with `ApplicationStatus` enum, `ApplicationKey` storage type, and both `approve_application` / `reject_application` functions
- **`FundEdu/src/errors.rs`**: Added `NotPending = 5` and `AlreadyRejected = 6` variants to `FundEduError`

## Behaviour

- Both functions require validator auth (mirrors `verify_cause` access-control pattern)
- Only `Pending` applications can be modified — returns `FundEduError::NotPending` otherwise
- Attempting to reject an already-approved application returns a custom error, not a state mutation

## Testing

11 tests added and passing:
- Approve/reject a pending application succeeds
- Approve/reject an already-approved application → `NotPending`
- Approve/reject an already-rejected application → `NotPending`
- Calling without auth panics with `Error(Auth, InvalidAction)`

`cargo fmt` and `cargo clippy -- -D warnings` both clean.