### PR TITLE
feat(fundedu): implement scholarship pool storage with incremental po…

### DIFF
--- a/FundEdu/Cargo.toml
+++ b/FundEdu/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+resolver = "2"
+members = ["contract"]
+
+[workspace.dependencies]
+soroban-sdk = "23.4.1"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/FundEdu/contract/.gitignore
+++ b/FundEdu/contract/.gitignore
@@ -1,0 +1,2 @@
+test_snapshots/
+Cargo.lock

--- a/FundEdu/contract/Cargo.toml
+++ b/FundEdu/contract/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fundedu-contract"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/FundEdu/contract/src/contract.rs
+++ b/FundEdu/contract/src/contract.rs
@@ -1,0 +1,39 @@
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+
+use crate::{
+    storage::{get_pool, next_pool_id, set_pool},
+    types::ScholarshipPool,
+};
+
+#[contract]
+pub struct FundEduContract;
+
+#[contractimpl]
+impl FundEduContract {
+    /// Create a new scholarship pool and return its assigned pool_id.
+    pub fn create_pool(
+        env: Env,
+        sponsor: Address,
+        name: String,
+        target_amount: i128,
+        token_address: Address,
+    ) -> u64 {
+        sponsor.require_auth();
+
+        let pool_id = next_pool_id(&env);
+        let pool = ScholarshipPool {
+            name,
+            sponsor,
+            target_amount,
+            token_address,
+            is_active: true,
+        };
+        set_pool(&env, pool_id, &pool);
+        pool_id
+    }
+
+    /// Retrieve a scholarship pool by its id. Returns None if not found.
+    pub fn get_pool(env: Env, pool_id: u64) -> Option<ScholarshipPool> {
+        get_pool(&env, pool_id)
+    }
+}

--- a/FundEdu/contract/src/lib.rs
+++ b/FundEdu/contract/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+mod contract;
+mod storage;
+mod types;
+
+pub use contract::FundEduContract;
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod test;

--- a/FundEdu/contract/src/storage.rs
+++ b/FundEdu/contract/src/storage.rs
@@ -1,0 +1,42 @@
+use soroban_sdk::Env;
+
+use crate::types::{DataKey, ScholarshipPool};
+
+const POOL_BUMP_AMOUNT: u32 = 100;
+const POOL_LIFETIME_THRESHOLD: u32 = 50;
+
+pub fn get_pool(env: &Env, pool_id: u64) -> Option<ScholarshipPool> {
+    let key = DataKey::Pool(pool_id);
+    if let Some(pool) = env
+        .storage()
+        .persistent()
+        .get::<DataKey, ScholarshipPool>(&key)
+    {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, POOL_LIFETIME_THRESHOLD, POOL_BUMP_AMOUNT);
+        Some(pool)
+    } else {
+        None
+    }
+}
+
+pub fn set_pool(env: &Env, pool_id: u64, pool: &ScholarshipPool) {
+    let key = DataKey::Pool(pool_id);
+    env.storage().persistent().set(&key, pool);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, POOL_LIFETIME_THRESHOLD, POOL_BUMP_AMOUNT);
+}
+
+pub fn next_pool_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::NextPoolId)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKey::NextPoolId, &(id + 1));
+    id
+}

--- a/FundEdu/contract/src/test.rs
+++ b/FundEdu/contract/src/test.rs
@@ -1,0 +1,62 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::contract::{FundEduContract, FundEduContractClient};
+
+fn setup() -> (Env, FundEduContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(FundEduContract, ());
+    let client = FundEduContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+#[test]
+fn test_create_pool_returns_incremental_ids() {
+    let (env, client) = setup();
+    let sponsor = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let id0 = client.create_pool(
+        &sponsor,
+        &String::from_str(&env, "STEM 2026"),
+        &50_000_000,
+        &token,
+    );
+    let id1 = client.create_pool(
+        &sponsor,
+        &String::from_str(&env, "Arts 2026"),
+        &20_000_000,
+        &token,
+    );
+
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+}
+
+#[test]
+fn test_get_pool_returns_correct_data() {
+    let (env, client) = setup();
+    let sponsor = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &sponsor,
+        &String::from_str(&env, "STEM 2026"),
+        &50_000_000,
+        &token,
+    );
+
+    let pool = client.get_pool(&pool_id).unwrap();
+    assert_eq!(pool.name, String::from_str(&env, "STEM 2026"));
+    assert_eq!(pool.target_amount, 50_000_000);
+    assert_eq!(pool.sponsor, sponsor);
+    assert!(pool.is_active);
+}
+
+#[test]
+fn test_get_pool_returns_none_for_missing_id() {
+    let (_env, client) = setup();
+    assert!(client.get_pool(&99).is_none());
+}

--- a/FundEdu/contract/src/types.rs
+++ b/FundEdu/contract/src/types.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::{contracttype, Address, String};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScholarshipPool {
+    pub name: String,
+    pub sponsor: Address,
+    pub target_amount: i128,
+    pub token_address: Address,
+    pub is_active: bool,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Pool(u64),
+    NextPoolId,
+}


### PR DESCRIPTION
close #284 


Title: feat(fundedu): implement scholarship pool storage with incremental pool_id

Body:
## Summary
Implements persistent storage management for scholarship pools inside FundEduContract.

## Changes
- `types.rs` — `ScholarshipPool` struct and `DataKey` enum (`Pool(u64)`, `NextPoolId`)
- `storage.rs` — `set_pool` / `get_pool` helpers using `env.storage().persistent()` with TTL bumping; `next_pool_id` counter via `env.storage().instance()`
- `contract.rs` — `create_pool` (returns incremental `u64` id) and `get_pool` (returns `Option<ScholarshipPool>`)
- `test.rs` — 3 tests: incremental IDs, correct data retrieval, missing pool returns `None`

## Acceptance Criteria
- [x] Storage sets/gets abstract away `DataKey` completely
- [x] `get_pool` exposes off-chain querying of active pools
- [x] Incremental `pool_id` counter in instance storage
- [x] All tests pass
- [x] Formatter and linter clear