### PR TITLE
feat: implement validator integration and authorization for pool stat…

### DIFF
--- a/contract/contract/src/base/types.rs
+++ b/contract/contract/src/base/types.rs
@@ -40,6 +40,7 @@ pub struct PoolConfig {
     pub duration: u64,
     pub created_at: u64,
     pub token_address: Address,
+    pub validator: Address,
 }
 
 #[contracttype]

--- a/contract/contract/src/crowdfunding.rs
+++ b/contract/contract/src/crowdfunding.rs
@@ -1063,6 +1063,7 @@ impl CrowdfundingTrait for CrowdfundingContract {
             duration,
             created_at: now,
             token_address: platform_token,
+            validator: creator.clone(), // Default validator is the creator
         };
 
         // Store pool configuration
@@ -1136,16 +1137,28 @@ impl CrowdfundingTrait for CrowdfundingContract {
     fn update_pool_state(
         env: Env,
         pool_id: u64,
+        caller: Address,
         new_state: PoolState,
     ) -> Result<(), CrowdfundingError> {
         if Self::is_paused(env.clone()) {
             return Err(CrowdfundingError::ContractPaused);
         }
-        // Ensure pool exists
+        
+        // Authorize caller - must be pool creator or validator
         let pool_key = StorageKey::Pool(pool_id);
         if !env.storage().instance().has(&pool_key) {
             return Err(CrowdfundingError::PoolNotFound);
         }
+        
+        let pool: PoolConfig = env.storage().instance().get(&pool_key).unwrap();
+        let creator_key = StorageKey::PoolCreator(pool_id);
+        let creator: Address = env.storage().instance().get(&creator_key).unwrap();
+        
+        if caller != creator && caller != pool.validator {
+            return Err(CrowdfundingError::Unauthorized);
+        }
+        
+        caller.require_auth();
 
         // Validate state transition (optional - could add more complex logic)
         let state_key = StorageKey::PoolState(pool_id);

--- a/contract/contract/src/interfaces/crowdfunding.rs
+++ b/contract/contract/src/interfaces/crowdfunding.rs
@@ -111,6 +111,7 @@ pub trait CrowdfundingTrait {
     fn update_pool_state(
         env: Env,
         pool_id: u64,
+        caller: Address,
         new_state: PoolState,
     ) -> Result<(), CrowdfundingError>;
 

--- a/contract/contract/test/close_pool_test.rs
+++ b/contract/contract/test/close_pool_test.rs
@@ -40,6 +40,7 @@ fn create_test_pool(
         duration: 86400, // 1 day
         created_at: env.ledger().timestamp(),
         token_address: token_address.clone(),
+        validator: creator.clone(), // For simplicity, creator is also validator
     };
 
     client.create_pool(creator, &config)
@@ -54,7 +55,7 @@ fn test_close_pool_success_after_disbursement() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update pool state to Disbursed
-    client.update_pool_state(&pool_id, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Disbursed);
 
     // Close the pool as admin
     client.close_pool(&pool_id, &admin);
@@ -73,7 +74,7 @@ fn test_close_pool_success_after_cancellation() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update pool state to Cancelled
-    client.update_pool_state(&pool_id, &PoolState::Cancelled);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Cancelled);
 
     // Close the pool as admin
     client.close_pool(&pool_id, &admin);
@@ -92,7 +93,7 @@ fn test_close_pool_already_closed() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update pool state to Disbursed
-    client.update_pool_state(&pool_id, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Disbursed);
 
     // Close the pool
     client.close_pool(&pool_id, &admin);
@@ -127,7 +128,7 @@ fn test_close_pool_paused_state() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update pool state to Paused
-    client.update_pool_state(&pool_id, &PoolState::Paused);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Paused);
 
     // Try to close - should fail
     let result = client.try_close_pool(&pool_id, &admin);
@@ -146,7 +147,7 @@ fn test_close_pool_completed_state() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update pool state to Completed
-    client.update_pool_state(&pool_id, &PoolState::Completed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Completed);
 
     // Try to close - should fail
     let result = client.try_close_pool(&pool_id, &admin);
@@ -176,7 +177,7 @@ fn test_close_pool_unauthorized() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update pool state to Disbursed
-    client.update_pool_state(&pool_id, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Disbursed);
 
     // Try to close as non-admin
     let unauthorized_user = Address::generate(&env);
@@ -205,7 +206,7 @@ fn test_is_closed_for_closed_pool() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update to Disbursed and close
-    client.update_pool_state(&pool_id, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Disbursed);
     client.close_pool(&pool_id, &admin);
 
     let is_closed = client.is_closed(&pool_id);
@@ -232,7 +233,7 @@ fn test_close_pool_emits_event() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update pool state to Disbursed
-    client.update_pool_state(&pool_id, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Disbursed);
 
     // Close the pool
     client.close_pool(&pool_id, &admin);
@@ -256,9 +257,9 @@ fn test_close_pool_multiple_pools() {
     let pool_id_3 = create_test_pool(&client, &env, &creator, &token_address);
 
     // Update states
-    client.update_pool_state(&pool_id_1, &PoolState::Disbursed);
-    client.update_pool_state(&pool_id_2, &PoolState::Cancelled);
-    client.update_pool_state(&pool_id_3, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id_1, &creator, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id_2, &creator, &PoolState::Cancelled);
+    client.update_pool_state(&pool_id_3, &creator, &PoolState::Disbursed);
 
     // Close pools 1 and 3
     client.close_pool(&pool_id_1, &admin);
@@ -289,7 +290,7 @@ fn test_close_pool_state_transition_sequence() {
     );
 
     // Transition to Disbursed
-    client.update_pool_state(&pool_id, &PoolState::Disbursed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Disbursed);
     assert!(!client.is_closed(&pool_id));
 
     // Now close should succeed
@@ -306,7 +307,7 @@ fn test_close_pool_after_refund_scenario() {
     let pool_id = create_test_pool(&client, &env, &creator, &token_address);
 
     // Simulate refund scenario by setting state to Cancelled
-    client.update_pool_state(&pool_id, &PoolState::Cancelled);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Cancelled);
 
     // Close the pool
     client.close_pool(&pool_id, &admin);
@@ -331,11 +332,11 @@ fn test_is_closed_for_different_states() {
     let pool_closed = create_test_pool(&client, &env, &creator, &token_address);
 
     // Set states
-    client.update_pool_state(&pool_paused, &PoolState::Paused);
-    client.update_pool_state(&pool_completed, &PoolState::Completed);
-    client.update_pool_state(&pool_cancelled, &PoolState::Cancelled);
-    client.update_pool_state(&pool_disbursed, &PoolState::Disbursed);
-    client.update_pool_state(&pool_closed, &PoolState::Disbursed);
+    client.update_pool_state(&pool_paused, &creator, &PoolState::Paused);
+    client.update_pool_state(&pool_completed, &creator, &PoolState::Completed);
+    client.update_pool_state(&pool_cancelled, &creator, &PoolState::Cancelled);
+    client.update_pool_state(&pool_disbursed, &creator, &PoolState::Disbursed);
+    client.update_pool_state(&pool_closed, &creator, &PoolState::Disbursed);
     client.close_pool(&pool_closed, &admin);
 
     // Verify is_closed returns false for all except Closed state

--- a/contract/contract/test/create_pool.rs
+++ b/contract/contract/test/create_pool.rs
@@ -43,6 +43,7 @@ fn test_create_pool_success() {
         duration: 30 * 24 * 60 * 60,
         created_at: env.ledger().timestamp(),
         token_address: token_address.clone(),
+        validator: creator.clone(),
     };
 
     let pool_id = client.create_pool(&creator, &config);
@@ -53,6 +54,7 @@ fn test_create_pool_success() {
     assert_eq!(saved.description, config.description);
     assert_eq!(saved.target_amount, config.target_amount);
     assert_eq!(saved.token_address, token_address);
+    assert_eq!(saved.validator, config.validator);
 }
 
 #[test]
@@ -75,6 +77,7 @@ fn test_create_pool_invalid_token_fails() {
         duration: 86400,
         created_at: env.ledger().timestamp(),
         token_address: wrong_token,
+        validator: creator.clone(),
     };
 
     let result = client.try_create_pool(&creator, &config);
@@ -99,6 +102,7 @@ fn test_create_pool_panic_description_length() {
         duration: 86400,
         created_at: env.ledger().timestamp(),
         token_address,
+        validator: creator.clone(),
     };
 
     client.create_pool(&creator, &config);

--- a/contract/contract/test/crowdfunding_test.rs
+++ b/contract/contract/test/crowdfunding_test.rs
@@ -621,10 +621,10 @@ fn test_update_pool_state() {
     );
 
     // Update state to Paused
-    client.update_pool_state(&pool_id, &PoolState::Paused);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Paused);
 
     // Update state to Completed
-    client.update_pool_state(&pool_id, &PoolState::Completed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Completed);
 }
 
 #[test]
@@ -668,13 +668,13 @@ fn test_update_pool_state_invalid_transition() {
     );
 
     // First complete the pool
-    client.update_pool_state(&pool_id, &PoolState::Completed);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Completed);
 
     // Try to change state from completed - should fail
-    let result = client.try_update_pool_state(&pool_id, &PoolState::Active);
+    let result = client.try_update_pool_state(&pool_id, &creator, &PoolState::Active);
     assert_eq!(result, Err(Ok(CrowdfundingError::InvalidPoolState)));
 
-    let result = client.try_update_pool_state(&pool_id, &PoolState::Paused);
+    let result = client.try_update_pool_state(&pool_id, &creator, &PoolState::Paused);
     assert_eq!(result, Err(Ok(CrowdfundingError::InvalidPoolState)));
 }
 
@@ -914,12 +914,12 @@ fn test_update_pool_state_blocked_when_paused() {
     client.pause();
 
     // Try to update pool state - should fail
-    let result = client.try_update_pool_state(&pool_id, &PoolState::Paused);
+    let result = client.try_update_pool_state(&pool_id, &creator, &PoolState::Paused);
     assert_eq!(result, Err(Ok(CrowdfundingError::ContractPaused)));
 
     // Unpause and verify it works
     client.unpause();
-    client.update_pool_state(&pool_id, &PoolState::Paused);
+    client.update_pool_state(&pool_id, &creator, &PoolState::Paused);
 }
 
 #[test]
@@ -3755,4 +3755,159 @@ fn test_refund_campaign() {
     // Trying second time fails
     let result = client.try_refund_campaign(&campaign_id, &donor);
     assert_eq!(result, Err(Ok(CrowdfundingError::NoContributionToRefund)));
+}
+
+#[test]
+fn test_update_pool_state_validator_authorization() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CrowdfundingContract, ());
+    let client = CrowdfundingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    client.initialize(&admin, &token_contract.address(), &0);
+
+    // Create a pool
+    let creator = Address::generate(&env);
+    let validator = Address::generate(&env);
+    let config = PoolConfig {
+        name: String::from_str(&env, "Test Pool"),
+        description: String::from_str(&env, "Test pool for validator auth"),
+        target_amount: 10_000i128,
+        min_contribution: 0,
+        is_private: false,
+        duration: 86400,
+        created_at: env.ledger().timestamp(),
+        token_address: token_contract.address(),
+        validator: validator.clone(),
+    };
+
+    let pool_id = client.create_pool(&creator, &config);
+
+    // Creator should be able to update state
+    client.update_pool_state(&pool_id, &creator, &PoolState::Paused);
+
+    // Validator should be able to update state
+    client.update_pool_state(&pool_id, &validator, &PoolState::Completed);
+
+    // Random address should not be able to update state
+    let random_user = Address::generate(&env);
+    let result = client.try_update_pool_state(&pool_id, &random_user, &PoolState::Active);
+    assert_eq!(result, Err(Ok(CrowdfundingError::Unauthorized)));
+}
+
+#[test]
+fn test_update_pool_state_lock_mechanics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CrowdfundingContract, ());
+    let client = CrowdfundingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    client.initialize(&admin, &token_contract.address(), &0);
+
+    // Create a pool
+    let creator = Address::generate(&env);
+    let config = PoolConfig {
+        name: String::from_str(&env, "Test Pool"),
+        description: String::from_str(&env, "Test pool for lock mechanics"),
+        target_amount: 10_000i128,
+        min_contribution: 0,
+        is_private: false,
+        duration: 86400,
+        created_at: env.ledger().timestamp(),
+        token_address: token_contract.address(),
+        validator: creator.clone(),
+    };
+
+    let pool_id = client.create_pool(&creator, &config);
+
+    // Set to Completed
+    client.update_pool_state(&pool_id, &creator, &PoolState::Completed);
+
+    // Try to change from Completed - should fail
+    let result = client.try_update_pool_state(&pool_id, &creator, &PoolState::Active);
+    assert_eq!(result, Err(Ok(CrowdfundingError::InvalidPoolState)));
+
+    let result = client.try_update_pool_state(&pool_id, &creator, &PoolState::Paused);
+    assert_eq!(result, Err(Ok(CrowdfundingError::InvalidPoolState)));
+
+    let result = client.try_update_pool_state(&pool_id, &creator, &PoolState::Cancelled);
+    assert_eq!(result, Err(Ok(CrowdfundingError::InvalidPoolState)));
+
+    // Set to Cancelled
+    client.update_pool_state(&pool_id, &creator, &PoolState::Cancelled);
+
+    // Try to change from Cancelled - should fail
+    let result = client.try_update_pool_state(&pool_id, &creator, &PoolState::Active);
+    assert_eq!(result, Err(Ok(CrowdfundingError::InvalidPoolState)));
+}
+
+#[test]
+fn test_validator_malicious_modification_prevention() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CrowdfundingContract, ());
+    let client = CrowdfundingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    client.initialize(&admin, &token_contract.address(), &0);
+
+    // Create multiple pools with different validators
+    let creator1 = Address::generate(&env);
+    let validator1 = Address::generate(&env);
+    let config1 = PoolConfig {
+        name: String::from_str(&env, "Pool 1"),
+        description: String::from_str(&env, "Pool 1"),
+        target_amount: 10_000i128,
+        min_contribution: 0,
+        is_private: false,
+        duration: 86400,
+        created_at: env.ledger().timestamp(),
+        token_address: token_contract.address(),
+        validator: validator1.clone(),
+    };
+    let pool_id1 = client.create_pool(&creator1, &config1);
+
+    let creator2 = Address::generate(&env);
+    let validator2 = Address::generate(&env);
+    let config2 = PoolConfig {
+        name: String::from_str(&env, "Pool 2"),
+        description: String::from_str(&env, "Pool 2"),
+        target_amount: 10_000i128,
+        min_contribution: 0,
+        is_private: false,
+        duration: 86400,
+        created_at: env.ledger().timestamp(),
+        token_address: token_contract.address(),
+        validator: validator2.clone(),
+    };
+    let pool_id2 = client.create_pool(&creator2, &config2);
+
+    // validator1 should not be able to modify pool_id2
+    let result = client.try_update_pool_state(&pool_id2, &validator1, &PoolState::Paused);
+    assert_eq!(result, Err(Ok(CrowdfundingError::Unauthorized)));
+
+    // creator1 should not be able to modify pool_id2
+    let result = client.try_update_pool_state(&pool_id2, &creator1, &PoolState::Paused);
+    assert_eq!(result, Err(Ok(CrowdfundingError::Unauthorized)));
+
+    // validator2 should not be able to modify pool_id1
+    let result = client.try_update_pool_state(&pool_id1, &validator2, &PoolState::Paused);
+    assert_eq!(result, Err(Ok(CrowdfundingError::Unauthorized)));
+
+    // But validator1 can modify pool_id1
+    client.update_pool_state(&pool_id1, &validator1, &PoolState::Paused);
+
+    // And validator2 can modify pool_id2
+    client.update_pool_state(&pool_id2, &validator2, &PoolState::Completed);
 }


### PR DESCRIPTION
…e updates

- Add validator field to PoolConfig struct for storing external validator addresses
- Modify create_pool to store validator during pool creation
- Update update_pool_state to require caller authorization (creator or validator only)
- Add comprehensive tests for validator authorization, lock mechanics, and security
- Prevent unauthorized state modifications and enforce proper access controls

Closes #296 [Validation] Model external Validator integration 
Closes #301 [Test] Unit Tests for the Validation/Approval Flow