### PR TITLE
feat(fundedu): implement create_pool with validation and FundEduError

### DIFF
--- a/FundEdu/contract/src/contract.rs
+++ b/FundEdu/contract/src/contract.rs
@@ -1,26 +1,74 @@
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, contracterror, Address, Env, String};
 
 use crate::{
     storage::{get_pool, next_pool_id, set_pool},
     types::ScholarshipPool,
 };
 
+/// Errors returned by FundEduContract entry points.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum FundEduError {
+    /// Pool name must not be empty.
+    InvalidSponsor = 1,
+    /// Pool is not in an active state.
+    PoolNotActive = 2,
+    /// A duplicate application was submitted.
+    DuplicateApplication = 3,
+    /// Caller is not the authorised validator.
+    UnauthorizedValidator = 4,
+    /// Application is not in Pending state.
+    NotPending = 5,
+    /// Application has already been rejected.
+    AlreadyRejected = 6,
+    /// `target_amount` must be strictly greater than zero.
+    InvalidFunding = 7,
+    /// No pool exists for the given `pool_id`.
+    PoolNotFound = 8,
+}
+
 #[contract]
 pub struct FundEduContract;
 
 #[contractimpl]
 impl FundEduContract {
-    /// Create a new scholarship pool and return its assigned pool_id.
+    /// Create a new scholarship pool.
+    ///
+    /// # Arguments
+    /// * `sponsor`       – Address funding the pool; must sign the transaction.
+    /// * `name`          – Human-readable pool name (must not be empty).
+    /// * `target_amount` – Total funding goal in token smallest units (must be > 0).
+    /// * `token_address` – SAC token used for contributions.
+    ///
+    /// # Returns
+    /// The unique `pool_id` assigned to the new pool (starts at 0, increments by 1).
+    ///
+    /// # Errors
+    /// * [`FundEduError::InvalidSponsor`]  – `name` is empty.
+    /// * [`FundEduError::InvalidFunding`]  – `target_amount` ≤ 0.
     pub fn create_pool(
         env: Env,
         sponsor: Address,
         name: String,
         target_amount: i128,
         token_address: Address,
-    ) -> u64 {
+    ) -> Result<u64, FundEduError> {
+        // ── Validate inputs before touching auth or storage ──────────────────
+        if name.is_empty() {
+            return Err(FundEduError::InvalidSponsor);
+        }
+
+        if target_amount <= 0 {
+            return Err(FundEduError::InvalidFunding);
+        }
+
+        // ── Require sponsor authorisation ────────────────────────────────────
         sponsor.require_auth();
 
+        // ── Allocate ID, build struct, persist ───────────────────────────────
         let pool_id = next_pool_id(&env);
+
         let pool = ScholarshipPool {
             name,
             sponsor,
@@ -28,11 +76,13 @@ impl FundEduContract {
             token_address,
             is_active: true,
         };
+
         set_pool(&env, pool_id, &pool);
-        pool_id
+
+        Ok(pool_id)
     }
 
-    /// Retrieve a scholarship pool by its id. Returns None if not found.
+    /// Retrieve a scholarship pool by its id. Returns `None` if not found.
     pub fn get_pool(env: Env, pool_id: u64) -> Option<ScholarshipPool> {
         get_pool(&env, pool_id)
     }

--- a/FundEdu/contract/src/lib.rs
+++ b/FundEdu/contract/src/lib.rs
@@ -4,7 +4,7 @@ mod contract;
 mod storage;
 mod types;
 
-pub use contract::FundEduContract;
+pub use contract::{FundEduContract, FundEduError};
 
 #[cfg(test)]
 extern crate std;

--- a/FundEdu/contract/src/test.rs
+++ b/FundEdu/contract/src/test.rs
@@ -2,7 +2,12 @@
 
 use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
-use crate::contract::{FundEduContract, FundEduContractClient};
+use crate::{
+    contract::{FundEduContract, FundEduContractClient, FundEduError},
+    types::ScholarshipPool,
+};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
 
 fn setup() -> (Env, FundEduContractClient<'static>) {
     let env = Env::default();
@@ -12,51 +17,126 @@ fn setup() -> (Env, FundEduContractClient<'static>) {
     (env, client)
 }
 
+// ── success cases ─────────────────────────────────────────────────────────────
+
 #[test]
-fn test_create_pool_returns_incremental_ids() {
+fn create_pool_success_returns_pool_id() {
     let (env, client) = setup();
     let sponsor = Address::generate(&env);
     let token = Address::generate(&env);
 
-    let id0 = client.create_pool(
-        &sponsor,
-        &String::from_str(&env, "STEM 2026"),
-        &50_000_000,
-        &token,
-    );
-    let id1 = client.create_pool(
-        &sponsor,
-        &String::from_str(&env, "Arts 2026"),
-        &20_000_000,
-        &token,
-    );
+    let pool_id = client
+        .create_pool(
+            &sponsor,
+            &String::from_str(&env, "STEM 2026"),
+            &50_000_000i128,
+            &token,
+        )
+        .unwrap();
+
+    assert_eq!(pool_id, 0);
+}
+
+#[test]
+fn create_pool_success_persists_correct_data() {
+    let (env, client) = setup();
+    let sponsor = Address::generate(&env);
+    let token = Address::generate(&env);
+    let name = String::from_str(&env, "Arts Fund");
+
+    let pool_id = client
+        .create_pool(&sponsor, &name, &10_000i128, &token)
+        .unwrap();
+
+    let pool: ScholarshipPool = client.get_pool(&pool_id).expect("pool must exist");
+
+    assert_eq!(pool.name, name);
+    assert_eq!(pool.sponsor, sponsor);
+    assert_eq!(pool.target_amount, 10_000i128);
+    assert_eq!(pool.token_address, token);
+    assert!(pool.is_active);
+}
+
+#[test]
+fn create_pool_increments_pool_id() {
+    let (env, client) = setup();
+    let sponsor = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let id0 = client
+        .create_pool(
+            &sponsor,
+            &String::from_str(&env, "Pool A"),
+            &1_000i128,
+            &token,
+        )
+        .unwrap();
+
+    let id1 = client
+        .create_pool(
+            &sponsor,
+            &String::from_str(&env, "Pool B"),
+            &2_000i128,
+            &token,
+        )
+        .unwrap();
 
     assert_eq!(id0, 0);
     assert_eq!(id1, 1);
 }
 
+// ── failure cases ─────────────────────────────────────────────────────────────
+
 #[test]
-fn test_get_pool_returns_correct_data() {
+fn create_pool_zero_amount_returns_invalid_funding() {
     let (env, client) = setup();
     let sponsor = Address::generate(&env);
     let token = Address::generate(&env);
 
-    let pool_id = client.create_pool(
+    let result = client.try_create_pool(
         &sponsor,
-        &String::from_str(&env, "STEM 2026"),
-        &50_000_000,
+        &String::from_str(&env, "Bad Pool"),
+        &0i128,
         &token,
     );
 
-    let pool = client.get_pool(&pool_id).unwrap();
-    assert_eq!(pool.name, String::from_str(&env, "STEM 2026"));
-    assert_eq!(pool.target_amount, 50_000_000);
-    assert_eq!(pool.sponsor, sponsor);
-    assert!(pool.is_active);
+    assert_eq!(result, Err(Ok(FundEduError::InvalidFunding)));
 }
 
 #[test]
-fn test_get_pool_returns_none_for_missing_id() {
+fn create_pool_negative_amount_returns_invalid_funding() {
+    let (env, client) = setup();
+    let sponsor = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let result = client.try_create_pool(
+        &sponsor,
+        &String::from_str(&env, "Negative Pool"),
+        &-1i128,
+        &token,
+    );
+
+    assert_eq!(result, Err(Ok(FundEduError::InvalidFunding)));
+}
+
+#[test]
+fn create_pool_empty_name_returns_invalid_sponsor() {
+    let (env, client) = setup();
+    let sponsor = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let result = client.try_create_pool(
+        &sponsor,
+        &String::from_str(&env, ""),
+        &5_000i128,
+        &token,
+    );
+
+    assert_eq!(result, Err(Ok(FundEduError::InvalidSponsor)));
+}
+
+#[test]
+fn get_pool_returns_none_for_unknown_id() {
     let (_env, client) = setup();
     assert!(client.get_pool(&99).is_none());
 }

--- a/FundEdu/src/errors.rs
+++ b/FundEdu/src/errors.rs
@@ -12,6 +12,9 @@ pub enum FundEduError {
     UnauthorizedValidator = 4,
     NotPending = 5,
     AlreadyRejected = 6,
+    // Validation errors
+    InvalidFunding = 7,  // target_amount must be > 0
+    PoolNotFound = 8,
 }
 
 #[cfg(test)]
@@ -26,6 +29,8 @@ mod tests {
         assert_eq!(FundEduError::UnauthorizedValidator as u32, 4);
         assert_eq!(FundEduError::NotPending as u32, 5);
         assert_eq!(FundEduError::AlreadyRejected as u32, 6);
+        assert_eq!(FundEduError::InvalidFunding as u32, 7);
+        assert_eq!(FundEduError::PoolNotFound as u32, 8);
     }
 
     #[test]
@@ -37,6 +42,8 @@ mod tests {
             FundEduError::UnauthorizedValidator,
             FundEduError::NotPending,
             FundEduError::AlreadyRejected,
+            FundEduError::InvalidFunding,
+            FundEduError::PoolNotFound,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {
@@ -52,5 +59,7 @@ mod tests {
         assert!(FundEduError::DuplicateApplication < FundEduError::UnauthorizedValidator);
         assert!(FundEduError::UnauthorizedValidator < FundEduError::NotPending);
         assert!(FundEduError::NotPending < FundEduError::AlreadyRejected);
+        assert!(FundEduError::AlreadyRejected < FundEduError::InvalidFunding);
+        assert!(FundEduError::InvalidFunding < FundEduError::PoolNotFound);
     }
 }


### PR DESCRIPTION
Closes #285 

Description
Sponsors need a way to instantiate a Scholarship Pool to support students. This issue tasks the contributor with creating the logic flow for pool instantiation.

Explicit Expectations

Implement create_pool inside the #[contractimpl] block.
Validate parameters (e.g., ensures funding amounts > 0).
Call sponsor.require_auth() to authorize the creation.
Save the newly structured Pool to storage and increment the pool_id counter.
Acceptance Criteria

Calling create_pool accurately updates the persistent storage.
Parameter validations revert securely with FundEduError using panic! or returning Result when invalid inputs are provided.
Contributor checklist:

Ensure the project builds successfully.
Add or update tests for all new/changed logic.
Make sure all tests pass.
Run the formatter / linter so code is properly formatted and consistent.

