### PR TITLE
Feat/revoke scholarship

### DIFF
--- a/contract/contract/src/base/events.rs
+++ b/contract/contract/src/base/events.rs
@@ -548,6 +548,11 @@ pub fn scholarship_rejected(env: &Env, pool_id: u64, applicant: Address, validat
     let topics = (Symbol::new(env, "scholarship_rejected"), pool_id, applicant);
     env.events().publish(topics, validator);
 }
+
+pub fn scholarship_revoked(env: &Env, pool_id: u64, student: Address, validator: Address) {
+    let topics = (Symbol::new(env, "scholarship_revoked"), pool_id, student);
+    env.events().publish(topics, validator);
+}
 pub fn school_registered(env: &Env, school_addr: Address) {
     let topics = (symbol_short!("SchReg"), school_addr);
     env.events().publish(topics, ());

--- a/contract/contract/src/base/types.rs
+++ b/contract/contract/src/base/types.rs
@@ -84,6 +84,7 @@ pub enum ApplicationStatus {
     Pending = 0,
     Approved = 1,
     Rejected = 2,
+    Revoked = 3,
 }
 
 /// A scholarship application submitted to a pool.
@@ -458,6 +459,7 @@ pub enum ApplicationStatus {
     Pending = 0,
     Approved = 1,
     Rejected = 2,
+    Revoked = 3,
 }
 
 #[contracttype]

--- a/contract/contract/src/contract.rs
+++ b/contract/contract/src/contract.rs
@@ -253,6 +253,10 @@ impl CrowdfundingTrait for FundEduContract {
         CrowdfundingContract::is_paused(env)
     }
 
+    fn pause_pool(env: Env, pool_id: u64, sponsor: Address) -> Result<(), CrowdfundingError> {
+        CrowdfundingContract::pause_pool(env, pool_id, sponsor)
+    }
+
     fn unpause_pool(env: Env, pool_id: u64, caller: Address) -> Result<(), CrowdfundingError> {
         CrowdfundingContract::unpause_pool(env, pool_id, caller)
     }

--- a/contract/contract/src/crowdfunding.rs
+++ b/contract/contract/src/crowdfunding.rs
@@ -1412,6 +1412,50 @@ impl CrowdfundingTrait for CrowdfundingContract {
             .unwrap_or(false)
     }
 
+    fn pause_pool(env: Env, pool_id: u64, sponsor: Address) -> Result<(), CrowdfundingError> {
+        // Pool must exist
+        let pool_key = StorageKey::Pool(pool_id);
+        if !env.storage().instance().has(&pool_key) {
+            return Err(CrowdfundingError::PoolNotFound);
+        }
+
+        // Only the pool sponsor (creator) may pause
+        let creator_key = StorageKey::PoolCreator(pool_id);
+        let creator: Address = env
+            .storage()
+            .instance()
+            .get(&creator_key)
+            .ok_or(CrowdfundingError::Unauthorized)?;
+
+        if sponsor != creator {
+            return Err(CrowdfundingError::Unauthorized);
+        }
+        sponsor.require_auth();
+
+        // Pool must currently be Active
+        let state_key = StorageKey::PoolState(pool_id);
+        let current_state: PoolState = env
+            .storage()
+            .instance()
+            .get(&state_key)
+            .unwrap_or(PoolState::Active);
+
+        if current_state == PoolState::Paused {
+            return Err(CrowdfundingError::ContractAlreadyPaused);
+        }
+
+        if current_state == PoolState::Closed || current_state == PoolState::Cancelled {
+            return Err(CrowdfundingError::InvalidPoolState);
+        }
+
+        env.storage().instance().set(&state_key, &PoolState::Paused);
+
+        events::pool_paused(&env, pool_id);
+        events::pool_state_updated(&env, pool_id, PoolState::Paused);
+
+        Ok(())
+    }
+
     fn unpause_pool(env: Env, pool_id: u64, caller: Address) -> Result<(), CrowdfundingError> {
         // Verify pool exists
         let pool_key = StorageKey::Pool(pool_id);
@@ -1836,7 +1880,7 @@ impl CrowdfundingTrait for CrowdfundingContract {
             .get(&state_key)
             .unwrap_or(PoolState::Active);
 
-        if current_state == PoolState::Closed || current_state == PoolState::Cancelled {
+        if current_state == PoolState::Closed || current_state == PoolState::Cancelled || current_state == PoolState::Paused {
             return Err(CrowdfundingError::InvalidPoolState);
         }
 

--- a/contract/contract/src/crowdfunding.rs
+++ b/contract/contract/src/crowdfunding.rs
@@ -2606,6 +2606,53 @@ impl ApplicationTrait for CrowdfundingContract {
             .get(&application_key)
             .ok_or(CrowdfundingError::ApplicationNotFound)
     }
+
+    fn revoke_scholarship(
+        env: Env,
+        pool_id: u64,
+        student: Address,
+        validator: Address,
+    ) -> Result<(), CrowdfundingError> {
+        // Pool must exist and validator must match
+        let pool_key = StorageKey::Pool(pool_id);
+        let pool: PoolConfig = env
+            .storage()
+            .instance()
+            .get(&pool_key)
+            .ok_or(CrowdfundingError::PoolNotFound)?;
+
+        if validator != pool.validator {
+            return Err(CrowdfundingError::Unauthorized);
+        }
+        validator.require_auth();
+
+        // Application must exist and be Approved
+        let application_key = StorageKey::Application(pool_id, student.clone());
+        let mut application: ApplicationDetails = env
+            .storage()
+            .instance()
+            .get(&application_key)
+            .ok_or(CrowdfundingError::ApplicationNotFound)?;
+
+        if application.status != ApplicationStatus::Approved {
+            return Err(CrowdfundingError::ApplicationAlreadyReviewed);
+        }
+
+        // Flip status to Revoked
+        application.status = ApplicationStatus::Revoked;
+        env.storage().instance().set(&application_key, &application);
+
+        // Return the previously allocated amount to the unallocated pool
+        let alloc_key = StorageKey::PoolAllocated(pool_id);
+        let current_alloc: i128 = env.storage().instance().get(&alloc_key).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&alloc_key, &current_alloc.saturating_sub(application.requested_amount));
+
+        events::scholarship_revoked(&env, pool_id, student, validator);
+
+        Ok(())
+    }
 }
 
 impl CrowdfundingContract {

--- a/contract/contract/src/interfaces/application.rs
+++ b/contract/contract/src/interfaces/application.rs
@@ -55,4 +55,16 @@ pub trait ApplicationTrait {
         pool_id: u64,
         applicant: Address,
     ) -> Result<ApplicationDetails, CrowdfundingError>;
+
+    /// Revoke an approved scholarship when a student drops out.
+    ///
+    /// Only the pool's designated validator may call this. The application must
+    /// currently be Approved. The previously allocated amount is returned to the
+    /// pool's unallocated balance so the sponsor can withdraw it.
+    fn revoke_scholarship(
+        env: Env,
+        pool_id: u64,
+        student: Address,
+        validator: Address,
+    ) -> Result<(), CrowdfundingError>;
 }

--- a/contract/contract/src/interfaces/crowdfunding.rs
+++ b/contract/contract/src/interfaces/crowdfunding.rs
@@ -152,6 +152,8 @@ pub trait CrowdfundingTrait {
 
     fn is_paused(env: Env) -> bool;
 
+    fn pause_pool(env: Env, pool_id: u64, sponsor: Address) -> Result<(), CrowdfundingError>;
+
     fn unpause_pool(env: Env, pool_id: u64, caller: Address) -> Result<(), CrowdfundingError>;
 
     fn contribute(

--- a/contract/contract/test/mod.rs
+++ b/contract/contract/test/mod.rs
@@ -23,5 +23,5 @@ mod application_test;
 mod validate_string_length_test;
 mod verify_cause;
 mod withdraw_platform_fees_test;
-mod application_test;
 mod unpause_pool_test;
+mod pause_pool_test;

--- a/contract/contract/test/mod.rs
+++ b/contract/contract/test/mod.rs
@@ -25,3 +25,4 @@ mod verify_cause;
 mod withdraw_platform_fees_test;
 mod unpause_pool_test;
 mod pause_pool_test;
+mod revoke_scholarship_test;

--- a/contract/contract/test/pause_pool_test.rs
+++ b/contract/contract/test/pause_pool_test.rs
@@ -1,0 +1,127 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, token, Address, Env, String};
+
+use crate::{
+    base::{
+        errors::CrowdfundingError,
+        types::{PoolConfig, PoolState},
+    },
+    crowdfunding::{CrowdfundingContract, CrowdfundingContractClient},
+};
+
+fn setup(env: &Env) -> (CrowdfundingContractClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(CrowdfundingContract, ());
+    let client = CrowdfundingContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    client.initialize(&admin, &token_address, &0);
+    (client, admin, token_address)
+}
+
+fn create_pool(
+    env: &Env,
+    client: &CrowdfundingContractClient<'_>,
+    token_address: &Address,
+) -> (u64, Address) {
+    let sponsor = Address::generate(env);
+    let token_admin_client = token::StellarAssetClient::new(env, token_address);
+    token_admin_client.mint(&sponsor, &10_000i128);
+
+    let config = PoolConfig {
+        name: String::from_str(env, "Test Pool"),
+        description: String::from_str(env, "A pool for testing"),
+        target_amount: 10_000,
+        min_contribution: 0,
+        is_private: false,
+        duration: 86400,
+        created_at: env.ledger().timestamp(),
+        token_address: token_address.clone(),
+        validator: sponsor.clone(),
+    };
+
+    let pool_id = client.create_pool(&sponsor, &config);
+    (pool_id, sponsor)
+}
+
+#[test]
+fn test_pause_pool_sets_paused_state() {
+    let env = Env::default();
+    let (client, _admin, token_address) = setup(&env);
+    let (pool_id, sponsor) = create_pool(&env, &client, &token_address);
+
+    client.pause_pool(&pool_id, &sponsor);
+
+    let state: PoolState = env
+        .storage()
+        .instance()
+        .get(&crate::base::types::StorageKey::PoolState(pool_id))
+        .unwrap();
+    assert_eq!(state, PoolState::Paused);
+}
+
+#[test]
+fn test_pause_pool_unauthorized_fails() {
+    let env = Env::default();
+    let (client, _admin, token_address) = setup(&env);
+    let (pool_id, _sponsor) = create_pool(&env, &client, &token_address);
+
+    let stranger = Address::generate(&env);
+    let result = client.try_pause_pool(&pool_id, &stranger);
+    assert_eq!(result, Err(Ok(CrowdfundingError::Unauthorized)));
+}
+
+#[test]
+fn test_pause_pool_already_paused_fails() {
+    let env = Env::default();
+    let (client, _admin, token_address) = setup(&env);
+    let (pool_id, sponsor) = create_pool(&env, &client, &token_address);
+
+    client.pause_pool(&pool_id, &sponsor);
+    let result = client.try_pause_pool(&pool_id, &sponsor);
+    assert_eq!(result, Err(Ok(CrowdfundingError::ContractAlreadyPaused)));
+}
+
+#[test]
+fn test_pause_pool_not_found_fails() {
+    let env = Env::default();
+    let (client, _admin, _token_address) = setup(&env);
+
+    let caller = Address::generate(&env);
+    let result = client.try_pause_pool(&999u64, &caller);
+    assert_eq!(result, Err(Ok(CrowdfundingError::PoolNotFound)));
+}
+
+#[test]
+fn test_claim_pool_funds_blocked_when_paused() {
+    let env = Env::default();
+    let (client, _admin, token_address) = setup(&env);
+    let (pool_id, sponsor) = create_pool(&env, &client, &token_address);
+
+    client.pause_pool(&pool_id, &sponsor);
+
+    let student = Address::generate(&env);
+    let result = client.try_claim_pool_funds(&pool_id, &student);
+    assert_eq!(result, Err(Ok(CrowdfundingError::InvalidPoolState)));
+}
+
+#[test]
+fn test_pause_then_unpause_allows_contributions() {
+    let env = Env::default();
+    let (client, _admin, token_address) = setup(&env);
+    let (pool_id, sponsor) = create_pool(&env, &client, &token_address);
+
+    client.pause_pool(&pool_id, &sponsor);
+    client.unpause_pool(&pool_id, &sponsor);
+
+    let contributor = Address::generate(&env);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_address);
+    token_admin_client.mint(&contributor, &1_000i128);
+
+    client.contribute(&pool_id, &contributor, &token_address, &500i128, &false);
+}

--- a/contract/contract/test/revoke_scholarship_test.rs
+++ b/contract/contract/test/revoke_scholarship_test.rs
@@ -1,0 +1,148 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, token, Address, Bytes, Env, String};
+
+use crate::{
+    base::{
+        errors::CrowdfundingError,
+        types::{ApplicationStatus, PoolConfig},
+    },
+    crowdfunding::{CrowdfundingContract, CrowdfundingContractClient},
+};
+
+fn setup(env: &Env) -> (CrowdfundingContractClient<'_>, Address, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(CrowdfundingContract, ());
+    let client = CrowdfundingContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.initialize(&admin, &token_address, &0);
+    (client, admin, token_address)
+}
+
+fn create_funded_pool(
+    env: &Env,
+    client: &CrowdfundingContractClient<'_>,
+    token_address: &Address,
+    validator: &Address,
+) -> u64 {
+    let sponsor = Address::generate(env);
+    let token_admin_client = token::StellarAssetClient::new(env, token_address);
+    token_admin_client.mint(&sponsor, &100_000i128);
+
+    let config = PoolConfig {
+        name: String::from_str(env, "Scholarship Pool"),
+        description: String::from_str(env, "Test pool"),
+        target_amount: 100_000,
+        min_contribution: 0,
+        is_private: false,
+        duration: 86400,
+        created_at: env.ledger().timestamp(),
+        token_address: token_address.clone(),
+        validator: validator.clone(),
+    };
+
+    client.create_pool(&sponsor, &config)
+}
+
+fn apply_and_approve(
+    env: &Env,
+    client: &CrowdfundingContractClient<'_>,
+    pool_id: u64,
+    validator: &Address,
+) -> Address {
+    let student = Address::generate(env);
+    let credentials = Bytes::from_array(env, &[1, 2, 3]);
+    client.apply_for_scholarship(&pool_id, &student, &credentials, &10_000i128);
+    client.approve_application(&pool_id, &student, validator, &None);
+    student
+}
+
+#[test]
+fn test_revoke_scholarship_sets_revoked_status() {
+    let env = Env::default();
+    let (client, _, token_address) = setup(&env);
+    let validator = Address::generate(&env);
+    let pool_id = create_funded_pool(&env, &client, &token_address, &validator);
+    let student = apply_and_approve(&env, &client, pool_id, &validator);
+
+    client.revoke_scholarship(&pool_id, &student, &validator);
+
+    let app = client.get_application(&pool_id, &student);
+    assert_eq!(app.status, ApplicationStatus::Revoked);
+}
+
+#[test]
+fn test_revoke_scholarship_unlocks_allocated_funds() {
+    let env = Env::default();
+    let (client, _, token_address) = setup(&env);
+    let validator = Address::generate(&env);
+    let pool_id = create_funded_pool(&env, &client, &token_address, &validator);
+    let student = apply_and_approve(&env, &client, pool_id, &validator);
+
+    // Before revoke: liquid = total - allocated
+    let liquid_before = client.get_pool_liquid_balance(&pool_id);
+
+    client.revoke_scholarship(&pool_id, &student, &validator);
+
+    // After revoke: allocated decreases, liquid increases by requested_amount
+    let liquid_after = client.get_pool_liquid_balance(&pool_id);
+    assert_eq!(liquid_after, liquid_before + 10_000i128);
+}
+
+#[test]
+fn test_revoke_scholarship_unauthorized_fails() {
+    let env = Env::default();
+    let (client, _, token_address) = setup(&env);
+    let validator = Address::generate(&env);
+    let pool_id = create_funded_pool(&env, &client, &token_address, &validator);
+    let student = apply_and_approve(&env, &client, pool_id, &validator);
+
+    let stranger = Address::generate(&env);
+    let result = client.try_revoke_scholarship(&pool_id, &student, &stranger);
+    assert_eq!(result, Err(Ok(CrowdfundingError::Unauthorized)));
+}
+
+#[test]
+fn test_revoke_scholarship_not_approved_fails() {
+    let env = Env::default();
+    let (client, _, token_address) = setup(&env);
+    let validator = Address::generate(&env);
+    let pool_id = create_funded_pool(&env, &client, &token_address, &validator);
+
+    // Apply but do NOT approve — status is Pending
+    let student = Address::generate(&env);
+    let credentials = Bytes::from_array(&env, &[1, 2, 3]);
+    client.apply_for_scholarship(&pool_id, &student, &credentials, &5_000i128);
+
+    let result = client.try_revoke_scholarship(&pool_id, &student, &validator);
+    assert_eq!(result, Err(Ok(CrowdfundingError::ApplicationAlreadyReviewed)));
+}
+
+#[test]
+fn test_revoke_scholarship_not_found_fails() {
+    let env = Env::default();
+    let (client, _, token_address) = setup(&env);
+    let validator = Address::generate(&env);
+    let pool_id = create_funded_pool(&env, &client, &token_address, &validator);
+
+    let ghost = Address::generate(&env);
+    let result = client.try_revoke_scholarship(&pool_id, &ghost, &validator);
+    assert_eq!(result, Err(Ok(CrowdfundingError::ApplicationNotFound)));
+}
+
+#[test]
+fn test_revoke_scholarship_pool_not_found_fails() {
+    let env = Env::default();
+    let (client, _, _) = setup(&env);
+    let validator = Address::generate(&env);
+    let student = Address::generate(&env);
+
+    let result = client.try_revoke_scholarship(&999u64, &student, &validator);
+    assert_eq!(result, Err(Ok(CrowdfundingError::PoolNotFound)));
+}


### PR DESCRIPTION
 Here's a summary of every change:                                                                  
                                                                                                     
  `base/types.rs` — added Revoked = 3 to both ApplicationStatus enums (the one used by               
  ScholarshipApplication and the one used by ApplicationDetails).                                    
                                                                                                     
  `base/events.rs` — added scholarship_revoked event emitting (pool_id, student) topics with         
  validator as data.                                                                                 
                                                                                                     
  `interfaces/application.rs` — added revoke_scholarship(env, pool_id, student, validator) to        
  ApplicationTrait.                                                                                  
                                                                                                     
  `crowdfunding.rs` — implemented revoke_scholarship in the ApplicationTrait impl:                   
                                                                                                     
  - Loads pool, enforces validator == pool.validator, calls validator.require_auth()                 
  - Loads application, requires status is Approved (errors with ApplicationAlreadyReviewed otherwise)
  - Sets status to Revoked                                                                           
  - Decrements PoolAllocated by application.requested_amount — this is the key unlock that frees the 
  capital back into the unallocated math used by get_pool_liquid_balance and withdraw_unallocated    
  - Emits scholarship_revoked event                                                                  
                                                                                                     
  `test/revoke_scholarship_test.rs` — 6 tests: status set to Revoked, liquid balance increases by the
  revoked amount, unauthorized fails, non-Approved status fails, application not found fails, pool   
  not found fails.                                

closes #343  