### PR TITLE
feat: add reusable Card component with variants, header, body, and fo…

### DIFF
--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const cardVariants = cva(
+  "rounded-xl w-full transition-all duration-300",
+  {
+    variants: {
+      variant: {
+        elevated:
+          "bg-white dark:bg-slate-900 shadow-md hover:shadow-xl border border-slate-100 dark:border-slate-800",
+        outlined:
+          "bg-transparent border border-slate-200 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500 shadow-none",
+        flat:
+          "bg-slate-50 dark:bg-slate-800/50 border border-transparent shadow-none",
+      },
+      hoverable: {
+        true: "hover:-translate-y-1 cursor-pointer",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      variant: "elevated",
+      hoverable: false,
+    },
+  }
+);
+
+export interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof cardVariants> {}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant, hoverable, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card"
+      className={cn(cardVariants({ variant, hoverable }), className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card-header"
+      className={cn("px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-800", className)}
+      {...props}
+    />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      data-slot="card-title"
+      className={cn("text-lg font-semibold text-slate-900 dark:text-white leading-tight", className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      data-slot="card-description"
+      className={cn("text-sm text-slate-500 dark:text-slate-400 mt-1", className)}
+      {...props}
+    />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardBody = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card-body"
+      className={cn("px-6 py-4", className)}
+      {...props}
+    />
+  )
+);
+CardBody.displayName = "CardBody";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      data-slot="card-footer"
+      className={cn(
+        "px-6 py-4 border-t border-slate-100 dark:border-slate-800 flex items-center gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardBody, CardFooter };


### PR DESCRIPTION
i Built a reusable Card component at frontend/src/components/ui/card.tsx using the
  project's existing cva + cn pattern. It exports six sub-components — Card, CardHeader,
  CardTitle, CardDescription, CardBody, CardFooter — and supports three variants (elevated,
  outlined, flat) plus an optional hoverable prop for lift-on-hover transitions. Fully
  typed with TypeScript and passes the build with no errors.


closes #392 