### PR TITLE
feat: Add reusable Header, Footer, and Button components

### DIFF
--- a/nevo_frontend/components/Button.tsx
+++ b/nevo_frontend/components/Button.tsx
@@ -1,0 +1,48 @@
+import React, { ButtonHTMLAttributes, FC } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger' | 'outlined';
+  size?: 'small' | 'medium' | 'large';
+  loading?: boolean;
+}
+
+export const Button: FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'medium',
+  loading = false,
+  disabled,
+  children,
+  className = '',
+  ...props
+}) => {
+  const baseStyles = 'inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
+  
+  const variants = {
+    primary: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
+    secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus:ring-gray-500',
+    danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+    outlined: 'border-2 border-gray-300 bg-transparent text-gray-700 hover:bg-gray-50 focus:ring-gray-500',
+  };
+
+  const sizes = {
+    small: 'px-3 py-1.5 text-sm',
+    medium: 'px-4 py-2 text-base',
+    large: 'px-6 py-3 text-lg',
+  };
+
+  return (
+    <button
+      className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {loading && (
+        <svg className="animate-spin -ml-1 mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+      )}
+      {children}
+    </button>
+  );
+};

--- a/nevo_frontend/components/Footer.tsx
+++ b/nevo_frontend/components/Footer.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Link from 'next/link';
+
+export const Footer = () => {
+    const currentYear = new Date().getFullYear();
+
+    return (
+        <footer className="mt-auto border-t border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-800 py-8 text-center text-sm">
+            <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row justify-between items-center gap-4">
+
+                <div className="flex flex-col items-center md:items-start">
+                    <Link href="/" className="text-xl font-bold text-blue-600 dark:text-blue-400">
+                        Nevo
+                    </Link>
+                    <p className="mt-2 text-gray-500 dark:text-gray-400">
+                        Empowering the Web3 ecosystem.
+                    </p>
+                </div>
+
+                <nav className="flex gap-6" aria-label="Footer">
+                    <Link href="/about" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
+                        About
+                    </Link>
+                    <Link href="/docs" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
+                        Docs
+                    </Link>
+                    <Link href="/contact" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
+                        Contact
+                    </Link>
+                    <Link href="/legal" className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
+                        Legal
+                    </Link>
+                </nav>
+
+                <div className="flex gap-4">
+                    <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-gray-500" aria-label="Twitter">
+                        <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84" />
+                        </svg>
+                    </a>
+                    <a href="https://github.com" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-gray-500" aria-label="GitHub">
+                        <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+                        </svg>
+                    </a>
+                </div>
+            </div>
+            <div className="mt-8 text-gray-400">
+                &copy; {currentYear} Nevo. All rights reserved.
+            </div>
+        </footer>
+    );
+};

--- a/nevo_frontend/components/Header.tsx
+++ b/nevo_frontend/components/Header.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { Button } from './Button';
+
+export const Header = () => {
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+    const navLinks = [
+        { name: 'Home', href: '/' },
+        { name: 'Browse Pools', href: '/pools' },
+        { name: 'Create Pool', href: '/create-pool' },
+        { name: 'Dashboard', href: '/dashboard' },
+    ];
+
+    return (
+        <header className="sticky top-0 z-50 w-full border-b border-gray-200 bg-white shadow-sm dark:bg-gray-900 dark:border-gray-800">
+            <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+                <div className="flex items-center">
+                    <Link href="/" className="flex items-center gap-2">
+                        <span className="text-2xl font-bold text-blue-600 dark:text-blue-400">Nevo</span>
+                    </Link>
+                </div>
+
+                {/* Desktop Navigation */}
+                <nav aria-label="Global" className="hidden md:flex md:gap-x-8">
+                    {navLinks.map((link) => (
+                        <Link
+                            key={link.name}
+                            href={link.href}
+                            className="text-sm font-semibold leading-6 text-gray-900 hover:text-blue-600 dark:text-gray-100 dark:hover:text-blue-400 transition-colors"
+                        >
+                            {link.name}
+                        </Link>
+                    ))}
+                </nav>
+
+                <div className="hidden md:flex md:items-center">
+                    <Button variant="primary" size="small">Connect Wallet</Button>
+                </div>
+
+                {/* Mobile menu button */}
+                <div className="flex md:hidden">
+                    <button
+                        type="button"
+                        className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700 dark:text-gray-200"
+                        onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+                        aria-expanded={isMobileMenuOpen}
+                    >
+                        <span className="sr-only">Open main menu</span>
+                        <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            {/* Mobile menu */}
+            {isMobileMenuOpen && (
+                <div className="md:hidden" role="dialog" aria-modal="true">
+                    <div className="space-y-1 px-4 pb-3 pt-2 sm:px-6">
+                        {navLinks.map((link) => (
+                            <Link
+                                key={link.name}
+                                href={link.href}
+                                className="block rounded-md px-3 py-2 text-base font-medium text-gray-900 hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-800"
+                                onClick={() => setIsMobileMenuOpen(false)}
+                            >
+                                {link.name}
+                            </Link>
+                        ))}
+                        <div className="mt-4 px-3">
+                            <Button variant="primary" size="medium" className="w-full">
+                                Connect Wallet
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </header>
+    );
+};

--- a/nevo_frontend/components/index.ts
+++ b/nevo_frontend/components/index.ts
@@ -1,0 +1,3 @@
+export * from './Button';
+export * from './Header';
+export * from './Footer';


### PR DESCRIPTION
This commit implements three frontend layout and UI components:
- Created `Button` component with variants (primary, secondary, danger, outlined) and loading/disabled states.
- Created `Header` component with responsive navigation and mobile hamburger menu.
- Created `Footer` component with dynamic copyright and social links. All styling is done via Tailwind CSS utility classes and includes interactive and accessibility features.

Closes #388, Closes #389, Closes #390