### PR TITLE
feat: add Avatar/Profile Image component (#431)

### DIFF
--- a/nevo_frontend/components/Avatar.tsx
+++ b/nevo_frontend/components/Avatar.tsx
@@ -1,0 +1,79 @@
+import React, { FC, useState } from 'react';
+
+export interface AvatarProps {
+  name?: string;
+  src?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+const sizes = {
+  sm: 'h-8 w-8 text-xs',
+  md: 'h-10 w-10 text-sm',
+  lg: 'h-14 w-14 text-base',
+};
+
+function getInitials(name?: string): string {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/);
+  return parts.length === 1
+    ? parts[0][0].toUpperCase()
+    : (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+export const Avatar: FC<AvatarProps> = ({
+  name,
+  src,
+  size = 'md',
+  className = '',
+}) => {
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>(
+    src ? 'loading' : 'error'
+  );
+  const base = `inline-flex items-center justify-center rounded-full overflow-hidden shrink-0 ${sizes[size]} ${className}`;
+
+  if (status === 'loading') {
+    return (
+      <span
+        className={`${base} bg-gray-200 animate-pulse`}
+        aria-label="Loading avatar"
+        role="img"
+      >
+        {src && (
+          <img
+            src={src}
+            alt={name ?? 'User avatar'}
+            className="h-full w-full object-cover"
+            onLoad={() => setStatus('loaded')}
+            onError={() => setStatus('error')}
+            style={{ display: 'none' }}
+          />
+        )}
+      </span>
+    );
+  }
+
+  if (src && status === 'loaded') {
+    return (
+      <span className={base}>
+        <img
+          src={src}
+          alt={name ?? 'User avatar'}
+          className="h-full w-full object-cover"
+          onError={() => setStatus('error')}
+        />
+      </span>
+    );
+  }
+
+  // fallback: initials
+  return (
+    <span
+      className={`${base} bg-blue-600 text-white font-medium select-none`}
+      role="img"
+      aria-label={name ? `Avatar for ${name}` : 'User avatar'}
+    >
+      {getInitials(name)}
+    </span>
+  );
+};

--- a/nevo_frontend/components/index.ts
+++ b/nevo_frontend/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Avatar';
 export * from './Button';
 export * from './Header';
 export * from './Footer';


### PR DESCRIPTION
- Displays user avatar image from URL
- Fallback to generated initials when no image or on error
- Size variants: sm, md, lg
- Loading skeleton state with animate-pulse
- Accessible role/aria-label on all states
- Mobile responsive via Tailwind CSS

  
  What changed
  
  - nevo_frontend/components/Avatar.tsx — new reusable Avatar component
  - nevo_frontend/components/index.ts — exports Avatar
  
  How it works
  
  - Renders a user image from a URL; falls back to generated initials on error or
  when no src is provided
  - Shows a skeleton pulse animation while the image loads
  - Three size variants: sm (32px), md (40px), lg (56px)
  - Accessible role="img" and aria-label on all render states
  
  Checklist
  
  - [x] Displays user avatar image
  - [x] Fallback to initials if no image / on error
  - [x] Size variants: sm, md, lg
  - [x] Loading skeleton state
  - [x] Accessible alt text
  - [x] Mobile responsive
  - [x] Build succeeds (npm run build ✓)

Closes #431 
