### PR TITLE
test(contract): add parameter validation and error message accuracy t…

### DIFF
--- a/nevo_contract/contracts/hello-world/src/test.rs
+++ b/nevo_contract/contracts/hello-world/src/test.rs
@@ -601,3 +601,336 @@ fn test_protocol_fees_reset_after_claim() {
     // Try to claim again - should panic (no fees accumulated)
     client.claim_protocol_fees(&admin, &token_address);
 }
+
+// ============= ISSUE #515: FUNCTION PARAMETER VALIDATION TESTS =============
+
+// (1) Out-of-range / zero values caught
+#[test]
+#[should_panic(expected = "Claim amount must be positive")]
+fn test_claim_funds_zero_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+    let token_address = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+    );
+    client.donate(&pool_id, &creator, &500_000_000);
+    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
+
+    // Zero is not positive — must be rejected
+    client.claim_funds(&student, &pool_id, &0i128, &token_address);
+}
+
+// (2) Invalid pool_id (non-existent) rejected with specific message
+#[test]
+#[should_panic(expected = "Pool not found")]
+fn test_get_pool_invalid_id_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    // Pool 999 was never created
+    client.get_pool(&999u32);
+}
+
+// (3) donate to non-existent pool rejected
+#[test]
+#[should_panic(expected = "Pool not found")]
+fn test_donate_invalid_pool_id_rejected() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let donor = Address::generate(&env);
+    client.donate(&999u32, &donor, &100_000_000);
+}
+
+// (4) apply_to_pool on non-existent pool rejected
+#[test]
+#[should_panic(expected = "Pool not found")]
+fn test_apply_to_pool_invalid_pool_id_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let student = Address::generate(&env);
+    client.apply_to_pool(&999u32, &student, &String::from_str(&env, "data"));
+}
+
+// (5) Duplicate application rejected
+#[test]
+#[should_panic(expected = "Duplicate application")]
+fn test_apply_to_pool_duplicate_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+    );
+
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
+    // Second application from same student must be rejected
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
+}
+
+// (6) create_pool_for_school with unregistered school rejected
+#[test]
+#[should_panic(expected = "School is not registered")]
+fn test_create_pool_for_school_unregistered_school_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let unregistered_school = Address::generate(&env);
+
+    client.create_pool_for_school(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+        &unregistered_school,
+    );
+}
+
+// (7) setup_application_milestones with empty milestones rejected
+#[test]
+#[should_panic(expected = "Milestones required")]
+fn test_setup_milestones_empty_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+    );
+
+    let empty: soroban_sdk::Vec<Milestone> = soroban_sdk::Vec::new(&env);
+    client.setup_application_milestones(&pool_id, &student, &empty);
+}
+
+// (8) setup_application_milestones where sum != goal rejected
+#[test]
+#[should_panic(expected = "Milestone total must equal pool goal")]
+fn test_setup_milestones_wrong_sum_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+    let goal: u128 = 1_000_000_000;
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &goal,
+    );
+
+    let mut milestones: soroban_sdk::Vec<Milestone> = soroban_sdk::Vec::new(&env);
+    milestones.push_back(Milestone { amount: 500_000_000 }); // sum != goal
+    client.setup_application_milestones(&pool_id, &student, &milestones);
+}
+
+// ============= ISSUE #506: ERROR MESSAGE ACCURACY TESTS =============
+
+// (1) Specific error for missing admin (not generic)
+#[test]
+#[should_panic(expected = "Admin not set")]
+fn test_register_school_without_admin_set_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let school = Address::generate(&env);
+    // Admin was never set — must say "Admin not set", not a generic error
+    client.register_school(&admin, &school);
+}
+
+// (2) Specific error when wrong admin calls register_school
+#[test]
+#[should_panic(expected = "Unauthorized admin")]
+fn test_register_school_wrong_admin_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let real_admin = Address::generate(&env);
+    let fake_admin = Address::generate(&env);
+    let school = Address::generate(&env);
+
+    client.set_admin(&real_admin);
+    // fake_admin is not the stored admin — must say "Unauthorized admin"
+    client.register_school(&fake_admin, &school);
+}
+
+// (3) Specific error when non-linked school tries to approve
+#[test]
+#[should_panic(expected = "Only linked school can approve")]
+fn test_approve_application_wrong_school_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let linked_school = Address::generate(&env);
+    let other_school = Address::generate(&env);
+    let student = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.register_school(&admin, &linked_school);
+
+    let pool_id = client.create_pool_for_school(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+        &linked_school,
+    );
+
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
+    // other_school is not the linked school — must say "Only linked school can approve"
+    client.approve_application(&pool_id, &other_school, &student, &true);
+}
+
+// (4) Specific error when approving a student who never applied
+#[test]
+#[should_panic(expected = "Student has not applied")]
+fn test_approve_application_no_application_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let school = Address::generate(&env);
+    let student = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.register_school(&admin, &school);
+
+    let pool_id = client.create_pool_for_school(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+        &school,
+    );
+
+    // Student never applied — must say "Student has not applied"
+    client.approve_application(&pool_id, &school, &student, &true);
+}
+
+// (5) Specific error when claiming from pool with no status set
+#[test]
+#[should_panic(expected = "Application status not found")]
+fn test_claim_funds_no_status_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+    let token_address = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+    );
+    client.donate(&pool_id, &creator, &500_000_000);
+
+    // No status set — must say "Application status not found", not a generic error
+    client.claim_funds(&student, &pool_id, &100_000_000i128, &token_address);
+}
+
+// (6) Specific error when overdrawing — not a generic arithmetic error
+#[test]
+#[should_panic(expected = "Overdraw attempt")]
+fn test_claim_funds_overdraw_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+    let token_address = Address::generate(&env);
+
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000,
+    );
+    client.donate(&pool_id, &creator, &100_000_000);
+    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
+
+    // Must say "Overdraw attempt", not a generic overflow/arithmetic error
+    client.claim_funds(&student, &pool_id, &999_000_000i128, &token_address);
+}
+
+// (7) Specific error when claiming fees with no admin set
+#[test]
+#[should_panic(expected = "Admin not set")]
+fn test_claim_protocol_fees_no_admin_set_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_address = Address::generate(&env);
+
+    // Admin was never set — must say "Admin not set"
+    client.claim_protocol_fees(&admin, &token_address);
+}
+
+// (8) Specific error when closing a non-existent pool
+#[test]
+#[should_panic(expected = "Pool not found")]
+fn test_close_pool_invalid_id_gives_specific_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    // Pool 42 never created — must say "Pool not found"
+    client.close_pool(&42u32);
+}


### PR DESCRIPTION
…ests

Closes #515 — Add tests for function parameter validation Closes #506 — Add tests for error message accuracy

## Issue #515 — Function Parameter Validation Tests

Added 8 tests covering all 5 validation requirements:

1. test_claim_funds_zero_amount_rejected
   - Verifies zero is rejected by claim_funds (out-of-range value).
   - Expects panic: 'Claim amount must be positive'.

2. test_get_pool_invalid_id_rejected
   - Verifies get_pool panics on a non-existent pool_id.
   - Expects panic: 'Pool not found'.

3. test_donate_invalid_pool_id_rejected
   - Verifies donate panics when pool_id does not exist.
   - Expects panic: 'Pool not found'.

4. test_apply_to_pool_invalid_pool_id_rejected
   - Verifies apply_to_pool panics on a non-existent pool_id.
   - Expects panic: 'Pool not found'.

5. test_apply_to_pool_duplicate_rejected
   - Verifies a student cannot submit two applications to the same pool.
   - Expects panic: 'Duplicate application'.

6. test_create_pool_for_school_unregistered_school_rejected
   - Verifies create_pool_for_school rejects an unregistered school address.
   - Expects panic: 'School is not registered'.

7. test_setup_milestones_empty_rejected
   - Verifies setup_application_milestones rejects an empty milestones vec.
   - Expects panic: 'Milestones required'.

8. test_setup_milestones_wrong_sum_rejected
   - Verifies milestone amounts must sum exactly to the pool goal.
   - Expects panic: 'Milestone total must equal pool goal'.

## Issue #506 — Error Message Accuracy Tests

Added 8 tests verifying each error condition produces its own specific, descriptive message rather than a generic one:

1. test_register_school_without_admin_set_gives_specific_error
   - Calling register_school before set_admin must say 'Admin not set'.

2. test_register_school_wrong_admin_gives_specific_error
   - Calling register_school with a non-matching admin must say 'Unauthorized admin'.

3. test_approve_application_wrong_school_gives_specific_error
   - A school that is not linked to the pool must get 'Only linked school can approve'.

4. test_approve_application_no_application_gives_specific_error
   - Approving a student who never applied must say 'Student has not applied'.

5. test_claim_funds_no_status_gives_specific_error
   - Claiming without any status set must say 'Application status not found'.

6. test_claim_funds_overdraw_gives_specific_error
   - Claiming more than collected must say 'Overdraw attempt', not a generic error.

7. test_claim_protocol_fees_no_admin_set_gives_specific_error
   - Claiming fees before admin is set must say 'Admin not set'.

8. test_close_pool_invalid_id_gives_specific_error
   - Closing a non-existent pool must say 'Pool not found'.
   
   closes #506 