### PR TITLE
feat: implement Donate to Pool flow 

### DIFF
--- a/nevo_frontend/app/pools/[id]/page.tsx
+++ b/nevo_frontend/app/pools/[id]/page.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useWalletStore } from '@/src/store/walletStore';
+import { DonateModal } from '@/components/DonateModal';
+import type { Pool } from '@/src/store/poolsStore';
+
+// TODO: Replace with real API call once backend pool endpoints are implemented
+const MOCK_POOLS: Pool[] = [
+  {
+    id: '1',
+    title: 'Clean Water Initiative',
+    description:
+      'Providing clean drinking water to rural communities in need. Every contribution helps us build wells and water purification systems in underserved areas.',
+    category: 'Humanitarian',
+    status: 'Active',
+    target: 10000,
+    raised: 6800,
+    imageColor: '#27926e',
+    creator: 'GABCDE1234567890ABCDE1234567890ABCDE1234567890ABCDE1234567890',
+    createdAt: '2025-03-01',
+  },
+  {
+    id: '2',
+    title: 'Open Source Dev Fund',
+    description:
+      'Supporting open source contributors building on Stellar. Funds go directly to developers maintaining critical infrastructure.',
+    category: 'Technology',
+    status: 'Active',
+    target: 5000,
+    raised: 5000,
+    imageColor: '#1c7459',
+    creator: 'GABCDE1234567890ABCDE1234567890ABCDE1234567890ABCDE1234567890',
+    createdAt: '2025-01-15',
+  },
+  {
+    id: '3',
+    title: 'Community Garden Project',
+    description:
+      'Building urban gardens to improve food security locally. We partner with city councils to transform unused land into productive green spaces.',
+    category: 'Environment',
+    status: 'Completed',
+    target: 3000,
+    raised: 3200,
+    imageColor: '#47ae88',
+    creator: 'GABCDE1234567890ABCDE1234567890ABCDE1234567890ABCDE1234567890',
+    createdAt: '2024-11-10',
+  },
+];
+
+export default function PoolDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { publicKey, initialize } = useWalletStore();
+  const [pool, setPool] = useState<Pool | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [donateOpen, setDonateOpen] = useState(false);
+
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  useEffect(() => {
+    // TODO: Replace with real fetch by pool id
+    const timer = setTimeout(() => {
+      setPool(MOCK_POOLS.find((p) => p.id === id) ?? null);
+      setLoading(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [id]);
+
+  if (loading) return <PoolDetailSkeleton />;
+
+  if (!pool) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-24 text-center">
+        <p className="text-lg font-semibold">Pool not found</p>
+        <Link
+          href="/pools"
+          className="mt-4 inline-block text-sm text-brand-600 hover:underline"
+        >
+          ← Back to pools
+        </Link>
+      </main>
+    );
+  }
+
+  const pct = Math.min(100, Math.round((pool.raised / pool.target) * 100));
+  const isActive = pool.status === 'Active';
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      {/* Back link */}
+      <Link
+        href="/pools"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+        aria-label="Back to pools list"
+      >
+        <ChevronLeftIcon />
+        All Pools
+      </Link>
+
+      {/* Pool header */}
+      <div
+        className="mb-6 h-40 w-full rounded-2xl sm:h-52"
+        style={{ backgroundColor: pool.imageColor }}
+        aria-hidden="true"
+      />
+
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-bold tracking-tight">{pool.title}</h1>
+            <StatusBadge status={pool.status} />
+          </div>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            {pool.category}
+            {pool.createdAt && ` · Created ${pool.createdAt}`}
+          </p>
+        </div>
+
+        {/* Donate button */}
+        <button
+          type="button"
+          onClick={() => setDonateOpen(true)}
+          disabled={!isActive}
+          aria-label={
+            isActive
+              ? `Donate to ${pool.title}`
+              : 'This pool is no longer accepting donations'
+          }
+          className="flex-shrink-0 rounded-full bg-brand-600 px-6 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+        >
+          Donate
+        </button>
+      </div>
+
+      {/* Progress */}
+      <section
+        aria-label="Fundraising progress"
+        className="mt-6 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-5"
+      >
+        <div className="mb-2 flex items-end justify-between">
+          <div>
+            <span className="text-2xl font-bold text-brand-600">
+              {pool.raised.toLocaleString()}
+            </span>
+            <span className="ml-1 text-sm text-[var(--color-text-muted)]">
+              XLM raised
+            </span>
+          </div>
+          <span className="text-sm text-[var(--color-text-muted)]">
+            of {pool.target.toLocaleString()} XLM goal
+          </span>
+        </div>
+        <div
+          className="h-2 w-full overflow-hidden rounded-full bg-[var(--color-border)]"
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${pct}% of goal reached`}
+        >
+          <div
+            className="h-full rounded-full bg-brand-500 transition-all"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <p className="mt-2 text-xs text-[var(--color-text-muted)]">
+          {pct}% funded
+        </p>
+      </section>
+
+      {/* Description */}
+      <section aria-label="Pool description" className="mt-6">
+        <h2 className="mb-2 text-base font-semibold">About this pool</h2>
+        <p className="text-sm leading-relaxed text-[var(--color-text-muted)]">
+          {pool.description}
+        </p>
+      </section>
+
+      {/* Wallet prompt if not connected */}
+      {!publicKey && isActive && (
+        <p className="mt-6 text-center text-sm text-[var(--color-text-muted)]">
+          Connect your wallet to donate to this pool.
+        </p>
+      )}
+
+      {/* Donation modal */}
+      {donateOpen && (
+        <DonateModal pool={pool} onClose={() => setDonateOpen(false)} />
+      )}
+    </main>
+  );
+}
+
+/* ── StatusBadge ──────────────────────────────────────────────────────────── */
+
+function StatusBadge({ status }: { status: Pool['status'] }) {
+  const styles =
+    status === 'Active'
+      ? 'bg-success-light text-success-dark'
+      : 'bg-[var(--color-surface-raised)] text-[var(--color-text-muted)] border border-[var(--color-border)]';
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${styles}`}
+      aria-label={`Pool status: ${status}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+/* ── Skeleton ─────────────────────────────────────────────────────────────── */
+
+function PoolDetailSkeleton() {
+  return (
+    <main
+      className="mx-auto max-w-3xl px-6 py-10"
+      aria-busy="true"
+      aria-label="Loading pool details"
+    >
+      <div className="mb-6 h-4 w-20 animate-pulse rounded bg-[var(--color-border)]" />
+      <div className="mb-6 h-40 w-full animate-pulse rounded-2xl bg-[var(--color-border)] sm:h-52" />
+      <div className="h-8 w-2/3 animate-pulse rounded bg-[var(--color-border)]" />
+      <div className="mt-3 h-4 w-1/3 animate-pulse rounded bg-[var(--color-border)]" />
+      <div className="mt-6 h-24 w-full animate-pulse rounded-2xl bg-[var(--color-border)]" />
+    </main>
+  );
+}
+
+/* ── Icons ────────────────────────────────────────────────────────────────── */
+
+function ChevronLeftIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 19.5 8.25 12l7.5-7.5"
+      />
+    </svg>
+  );
+}

--- a/nevo_frontend/components/DonateModal.tsx
+++ b/nevo_frontend/components/DonateModal.tsx
@@ -1,0 +1,394 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useWalletStore } from '@/src/store/walletStore';
+import { useDonationsStore } from '@/src/store/donationsStore';
+import type { Pool } from '@/src/store/poolsStore';
+import { WalletAddress } from './WalletAddress';
+
+type Asset = 'XLM' | 'USDC';
+type Step = 'form' | 'loading' | 'success' | 'error';
+
+const MIN_AMOUNT = 1;
+const MAX_AMOUNT = 100_000;
+// Mock fee estimate (Stellar base fee in XLM)
+const TX_FEE_XLM = '0.00001';
+
+interface DonateModalProps {
+  pool: Pool;
+  onClose: () => void;
+}
+
+export function DonateModal({ pool, onClose }: DonateModalProps) {
+  const { publicKey, balances } = useWalletStore();
+  const { addDonation } = useDonationsStore();
+
+  const [asset, setAsset] = useState<Asset>('XLM');
+  const [amount, setAmount] = useState('');
+  const [step, setStep] = useState<Step>('form');
+  const [errorMsg, setErrorMsg] = useState('');
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus amount input on open
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const availableBalance =
+    asset === 'XLM' ? (balances?.xlm ?? '0') : (balances?.usdc ?? '0');
+
+  const numAmount = parseFloat(amount);
+  const amountValid =
+    !isNaN(numAmount) && numAmount >= MIN_AMOUNT && numAmount <= MAX_AMOUNT;
+  const amountError =
+    amount !== '' && !amountValid
+      ? numAmount < MIN_AMOUNT
+        ? `Minimum donation is ${MIN_AMOUNT} ${asset}`
+        : `Maximum donation is ${MAX_AMOUNT.toLocaleString()} ${asset}`
+      : '';
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!amountValid || !publicKey) return;
+
+    setStep('loading');
+
+    // TODO: Replace with real contract call once backend is integrated
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const shouldFail = false; // flip to true to test error state
+    if (shouldFail) {
+      setErrorMsg('Transaction rejected by the network. Please try again.');
+      setStep('error');
+      return;
+    }
+
+    const donation = {
+      id: `mock-${Date.now()}`,
+      poolId: pool.id,
+      poolName: pool.title,
+      amount,
+      asset,
+      txHash: `mock-tx-${Math.random().toString(36).slice(2)}`,
+      timestamp: new Date().toISOString(),
+      status: 'confirmed' as const,
+    };
+    addDonation(donation);
+    setStep('success');
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="donate-modal-title"
+    >
+      {/* Backdrop */}
+      <div
+        ref={backdropRef}
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full max-w-md rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-xl">
+        {/* Header */}
+        <div className="mb-5 flex items-start justify-between gap-3">
+          <div>
+            <h2
+              id="donate-modal-title"
+              className="text-base font-semibold leading-tight"
+            >
+              Donate to Pool
+            </h2>
+            <p className="mt-0.5 text-sm text-[var(--color-text-muted)] line-clamp-1">
+              {pool.title}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close donation modal"
+            className="flex-shrink-0 flex size-8 items-center justify-center rounded-lg border border-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface-raised)] transition-colors"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        {/* ── Form step ── */}
+        {step === 'form' && (
+          <form onSubmit={handleSubmit} noValidate>
+            {/* Wallet confirmation */}
+            {publicKey && (
+              <div className="mb-4 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-3">
+                <p className="mb-1.5 text-xs text-[var(--color-text-muted)]">
+                  Donating from
+                </p>
+                <WalletAddress address={publicKey} className="text-xs" />
+              </div>
+            )}
+
+            {/* Denomination selector */}
+            <div className="mb-4">
+              <label className="mb-1.5 block text-sm font-medium">
+                Currency
+              </label>
+              <div
+                role="radiogroup"
+                aria-label="Select currency"
+                className="flex gap-2"
+              >
+                {(['XLM', 'USDC'] as Asset[]).map((a) => (
+                  <button
+                    key={a}
+                    type="button"
+                    role="radio"
+                    aria-checked={asset === a}
+                    onClick={() => setAsset(a)}
+                    className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 ${
+                      asset === a
+                        ? 'border-brand-600 bg-brand-50 text-brand-700'
+                        : 'border-[var(--color-border)] hover:bg-[var(--color-surface-raised)]'
+                    }`}
+                  >
+                    {a}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-1.5 text-xs text-[var(--color-text-muted)]">
+                Available:{' '}
+                <span className="font-medium">
+                  {availableBalance} {asset}
+                </span>
+              </p>
+            </div>
+
+            {/* Amount input */}
+            <div className="mb-4">
+              <label
+                htmlFor="donate-amount"
+                className="mb-1.5 block text-sm font-medium"
+              >
+                Amount
+              </label>
+              <div className="relative">
+                <input
+                  ref={inputRef}
+                  id="donate-amount"
+                  type="number"
+                  inputMode="decimal"
+                  min={MIN_AMOUNT}
+                  max={MAX_AMOUNT}
+                  step="any"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  placeholder={`Min ${MIN_AMOUNT} ${asset}`}
+                  aria-describedby={
+                    amountError ? 'amount-error' : 'amount-hint'
+                  }
+                  aria-invalid={!!amountError}
+                  className="w-full rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2.5 pr-16 text-sm focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600 aria-[invalid=true]:border-error"
+                />
+                <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm font-medium text-[var(--color-text-muted)]">
+                  {asset}
+                </span>
+              </div>
+              {amountError ? (
+                <p
+                  id="amount-error"
+                  role="alert"
+                  className="mt-1 text-xs text-error"
+                >
+                  {amountError}
+                </p>
+              ) : (
+                <p
+                  id="amount-hint"
+                  className="mt-1 text-xs text-[var(--color-text-muted)]"
+                >
+                  Max {MAX_AMOUNT.toLocaleString()} {asset}
+                </p>
+              )}
+            </div>
+
+            {/* Transaction fee estimate */}
+            <div className="mb-5 flex items-center justify-between rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-2.5 text-sm">
+              <span className="text-[var(--color-text-muted)]">
+                Estimated network fee
+              </span>
+              <span className="font-medium">{TX_FEE_XLM} XLM</span>
+            </div>
+
+            <button
+              type="submit"
+              disabled={!amountValid || !publicKey}
+              className="w-full rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+            >
+              Donate {amountValid ? `${amount} ${asset}` : ''}
+            </button>
+
+            {!publicKey && (
+              <p className="mt-3 text-center text-xs text-[var(--color-text-muted)]">
+                Connect your wallet to donate.
+              </p>
+            )}
+          </form>
+        )}
+
+        {/* ── Loading step ── */}
+        {step === 'loading' && (
+          <div
+            className="flex flex-col items-center gap-4 py-8"
+            aria-live="polite"
+            aria-busy="true"
+          >
+            <div className="size-12 animate-spin rounded-full border-4 border-[var(--color-border)] border-t-brand-600" />
+            <p className="text-sm font-medium">Processing transaction…</p>
+            <p className="text-xs text-[var(--color-text-muted)]">
+              Please wait while your donation is being submitted.
+            </p>
+          </div>
+        )}
+
+        {/* ── Success step ── */}
+        {step === 'success' && (
+          <div
+            className="flex flex-col items-center gap-4 py-6 text-center"
+            aria-live="polite"
+          >
+            <div className="flex size-14 items-center justify-center rounded-full bg-success-light text-success">
+              <CheckCircleIcon />
+            </div>
+            <div>
+              <p className="font-semibold">Donation successful!</p>
+              <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+                You donated{' '}
+                <span className="font-medium">
+                  {amount} {asset}
+                </span>{' '}
+                to <span className="font-medium">{pool.title}</span>.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="mt-2 w-full rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+            >
+              Done
+            </button>
+          </div>
+        )}
+
+        {/* ── Error step ── */}
+        {step === 'error' && (
+          <div
+            className="flex flex-col items-center gap-4 py-6 text-center"
+            aria-live="polite"
+          >
+            <div className="flex size-14 items-center justify-center rounded-full bg-error-light text-error">
+              <XCircleIcon />
+            </div>
+            <div>
+              <p className="font-semibold">Donation failed</p>
+              <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+                {errorMsg}
+              </p>
+            </div>
+            <div className="mt-2 flex w-full gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 rounded-xl border border-[var(--color-border)] px-4 py-2.5 text-sm font-medium hover:bg-[var(--color-surface-raised)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setStep('form');
+                  setErrorMsg('');
+                }}
+                className="flex-1 rounded-xl bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Icons ─────────────────────────────────────────────────────────────── */
+
+function CloseIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 18 18 6M6 6l12 12"
+      />
+    </svg>
+  );
+}
+
+function CheckCircleIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="size-7"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+      />
+    </svg>
+  );
+}
+
+function XCircleIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="size-7"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+      />
+    </svg>
+  );
+}

--- a/nevo_frontend/components/index.ts
+++ b/nevo_frontend/components/index.ts
@@ -3,3 +3,4 @@ export * from './Button';
 export * from './Header';
 export * from './Footer';
 export * from './WalletAddress';
+export * from './DonateModal';


### PR DESCRIPTION
Closes #398 

## What changed
- Added DonateModal component with 4 states: form, loading, success, error
- Added /pools/[id] pool detail page with a Donate button that opens the modal
- Exported DonateModal from components/index.ts

## Details
- Denomination selector (XLM / USDC) with live balance display
- Amount input with min/max validation
- Wallet address confirmation before submission
- Estimated network fee displayed (0.00001 XLM)
- Mock transaction submission — marked with TODO for backend integration
- Donate button disabled on completed pools

## Testing
- [ ] Lint passes
- [ ] Prettier passes
- [ ] Build passes

│ Scope: nevo_frontend only