### PR TITLE
feat: setup Sentry error logging and monitoring (#416)

### DIFF
--- a/nevo_frontend/.env.example
+++ b/nevo_frontend/.env.example
@@ -1,0 +1,8 @@
+# Sentry - Error Monitoring
+# Get these from https://sentry.io/settings/<org>/projects/<project>/keys/
+NEXT_PUBLIC_SENTRY_DSN=
+
+# Used during build for source map uploads (optional)
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_AUTH_TOKEN=

--- a/nevo_frontend/app/global-error.tsx
+++ b/nevo_frontend/app/global-error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <div style={{ padding: '2rem', textAlign: 'center' }}>
+          <h2>Something went wrong</h2>
+          <button onClick={reset}>Try again</button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/nevo_frontend/next.config.ts
+++ b/nevo_frontend/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from 'next';
+import { withSentryConfig } from '@sentry/nextjs';
 
 const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  silent: !process.env.CI,
+  widenClientFileUpload: true,
+  disableLogger: true,
+  automaticVercelMonitors: true,
+});

--- a/nevo_frontend/package.json
+++ b/nevo_frontend/package.json
@@ -19,6 +19,7 @@
     ]
   },
   "dependencies": {
+    "@sentry/nextjs": "^8.47.0",
     "@stellar/freighter-api": "^6.0.1",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/nevo_frontend/sentry.client.config.ts
+++ b/nevo_frontend/sentry.client.config.ts
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  enabled: process.env.NODE_ENV === 'production',
+  tracesSampleRate: 1.0,
+  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: 0.1,
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+});

--- a/nevo_frontend/sentry.edge.config.ts
+++ b/nevo_frontend/sentry.edge.config.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  enabled: process.env.NODE_ENV === 'production',
+  tracesSampleRate: 1.0,
+});

--- a/nevo_frontend/sentry.server.config.ts
+++ b/nevo_frontend/sentry.server.config.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+  enabled: process.env.NODE_ENV === 'production',
+  tracesSampleRate: 1.0,
+});


### PR DESCRIPTION
- Add @sentry/nextjs dependency
- Configure Sentry for client, server, and edge runtimes
- Wrap Next.js config with withSentryConfig for source maps
- Add global-error.tsx to capture unhandled errors via Sentry
- Enable session replay with privacy-safe settings (maskAllText, blockAllMedia)
- Disable Sentry in development, enabled only in production
- Add .env.example documenting required SENTRY_DSN and build vars
- Performance monitoring via tracesSampleRate

closes #416 