### PR TITLE
feat: add reusable pool card for listings and dashboard

### DIFF
--- a/frontend/src/app/dashboard/my-pools/page.tsx
+++ b/frontend/src/app/dashboard/my-pools/page.tsx
@@ -1,4 +1,21 @@
-import Link from "next/link";
+import Link from "next/link"
+import { PoolCard } from "@/components/PoolCard"
+
+const DASHBOARD_POOLS = [
+  {
+    id: "my-1",
+    title: "Community School Supplies",
+    description: "Providing notebooks, backpacks, and uniforms for students ahead of the new term.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1503676260728-1c00da094a0b?auto=format&fit=crop&q=80&w=800",
+    goalAmount: 12000,
+    raisedAmount: 6400,
+    donorCount: 76,
+    creatorName: "You",
+    creatorAvatarUrl: "https://i.pravatar.cc/120?img=15",
+    status: "Open" as const,
+  },
+]
 
 export default function MyPoolsPage() {
   return (
@@ -14,7 +31,7 @@ export default function MyPoolsPage() {
         </div>
         <Link
           href="/dashboard/pools/create"
-          className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-emerald-500 to-cyan-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition-all duration-200 hover:brightness-110 hover:shadow-emerald-500/50 active:scale-95"
+          className="inline-flex items-center gap-2 rounded-xl bg-linear-to-r from-emerald-500 to-cyan-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-emerald-500/30 transition-all duration-200 hover:brightness-110 hover:shadow-emerald-500/50 active:scale-95"
         >
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
@@ -23,23 +40,11 @@ export default function MyPoolsPage() {
         </Link>
       </header>
 
-      <section className="rounded-xl border border-slate-800/80 bg-slate-900/50 p-8 text-center backdrop-blur-sm">
-        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-slate-800 text-slate-500">
-          <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
-          </svg>
-        </div>
-        <h3 className="mt-4 text-base font-semibold text-white">No pools yet</h3>
-        <p className="mt-1 text-sm text-slate-500">
-          Get started by creating your first donation pool.
-        </p>
-        <Link
-          href="/dashboard/pools/create"
-          className="mt-5 inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-emerald-500/40 hover:text-emerald-400"
-        >
-          Create your first pool →
-        </Link>
+      <section className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {DASHBOARD_POOLS.map((pool) => (
+          <PoolCard key={pool.id} {...pool} />
+        ))}
       </section>
     </div>
-  );
+  )
 }

--- a/frontend/src/app/pools/[id]/page.tsx
+++ b/frontend/src/app/pools/[id]/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link"
+
+interface PoolDetailPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function PoolDetailPage({ params }: PoolDetailPageProps) {
+  const { id } = await params
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-16 text-white sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-4xl rounded-2xl border border-slate-800 bg-slate-900/70 p-8">
+        <p className="text-sm text-slate-400">Pool Detail</p>
+        <h1 className="mt-2 text-3xl font-bold">Pool #{id}</h1>
+        <p className="mt-4 text-slate-300">
+          This page is ready for full pool detail integration. The listing cards now navigate here.
+        </p>
+        <Link
+          href="/explore"
+          className="mt-8 inline-flex rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-700"
+        >
+          Back to pools
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/components/PoolCard.tsx
+++ b/frontend/src/components/PoolCard.tsx
@@ -1,43 +1,43 @@
-"use client";
+import Link from "next/link"
+import Image from "next/image"
+import { Users } from "lucide-react"
 
-import React, { useState } from "react";
-import { TrendingUp, Users } from "lucide-react";
-import Image from "next/image";
-import { DonationModal } from "./DonationModal";
-import { Button } from "./ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { StatusBadge } from "@/components/ui/status-badge"
+
+type PoolStatus = "Open" | "Closed"
 
 export interface PoolCardProps {
-  id: string;
-  title: string;
-  description: string;
-  category: string;
-  imageUrl: string;
-  goalAmount: number;
-  raisedAmount: number;
-  contributorsCount: number;
-  poolId: string;
-  contractId: string;
+  id: string
+  title: string
+  description: string
+  imageUrl: string
+  goalAmount: number
+  raisedAmount: number
+  donorCount: number
+  creatorName: string
+  creatorAvatarUrl: string
+  status: PoolStatus
 }
 
-export const PoolCard: React.FC<PoolCardProps> = ({
+export const PoolCard = ({
+  id,
   title,
   description,
-  category,
   imageUrl,
   goalAmount,
   raisedAmount,
-  contributorsCount,
-  poolId,
-  contractId,
-}) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const progressPercent = Math.min((raisedAmount / goalAmount) * 100, 100);
+  donorCount,
+  creatorName,
+  creatorAvatarUrl,
+  status,
+}: PoolCardProps) => {
+  const progress = goalAmount > 0 ? Math.min((raisedAmount / goalAmount) * 100, 100) : 0
 
   return (
-    <>
-      <div className="group bg-slate-50 dark:bg-slate-800/50 rounded-2xl border border-slate-200 dark:border-slate-700 overflow-hidden hover:shadow-2xl transition-all duration-300 hover:-translate-y-1 cursor-pointer flex flex-col h-full">
-        {/* Image Container with Hover Scale Result */}
-        <div className="relative h-48 w-full overflow-hidden">
+    <Link href={`/pools/${id}`} className="block h-full">
+      <Card className="group flex h-full flex-col overflow-hidden border-slate-200/70 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/70">
+        <div className="relative h-44 w-full overflow-hidden">
           <Image
             src={imageUrl}
             alt={title}
@@ -45,82 +45,58 @@ export const PoolCard: React.FC<PoolCardProps> = ({
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             className="object-cover transition-transform duration-500 group-hover:scale-105"
           />
-          {/* Category Badge over image */}
-          <div className="absolute top-4 left-4">
-            <span className="px-3 py-1 text-xs font-semibold rounded-full bg-[#0F172A]/80 text-white backdrop-blur-sm border border-slate-700">
-              {category}
-            </span>
+          <div className="absolute left-3 top-3">
+            <StatusBadge variant={status === "Open" ? "success" : "default"}>
+              {status}
+            </StatusBadge>
           </div>
         </div>
 
-        {/* Card Content */}
-        <div className="p-6 flex flex-col flex-grow">
-          <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-2 line-clamp-1 group-hover:text-blue-500 dark:group-hover:text-cyan-400 transition-colors">
-            {title}
-          </h3>
-          <p className="text-slate-600 dark:text-slate-400 text-sm mb-6 line-clamp-2 flex-grow">
-            {description}
-          </p>
+        <CardHeader className="space-y-3 pb-4">
+          <div className="flex items-center gap-3">
+            <Image
+              src={creatorAvatarUrl}
+              alt={creatorName}
+              width={34}
+              height={34}
+              className="h-8 w-8 rounded-full object-cover ring-2 ring-white dark:ring-slate-800"
+            />
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              by <span className="font-semibold text-slate-800 dark:text-slate-200">{creatorName}</span>
+            </p>
+          </div>
+          <CardTitle className="line-clamp-1 text-xl">{title}</CardTitle>
+          <CardDescription className="line-clamp-2">{description}</CardDescription>
+        </CardHeader>
 
-          {/* Progress Section */}
-          <div className="mt-auto space-y-4">
-            <div className="flex justify-between items-end text-sm">
-              <div>
-                <p className="text-slate-500 dark:text-slate-400">Raised</p>
-                <p className="font-bold text-slate-900 dark:text-white text-lg">
-                  ${raisedAmount.toLocaleString()}
-                </p>
-              </div>
-              <div className="text-right">
-                <p className="text-slate-500 dark:text-slate-400">Goal</p>
-                <p className="font-semibold text-slate-700 dark:text-slate-300">
-                  ${goalAmount.toLocaleString()}
-                </p>
-              </div>
+        <CardContent className="mt-auto space-y-4">
+          <div className="flex items-end justify-between gap-2 text-sm">
+            <div>
+              <p className="text-slate-500 dark:text-slate-400">Donated</p>
+              <p className="text-lg font-bold text-slate-900 dark:text-white">${raisedAmount.toLocaleString()}</p>
             </div>
+            <p className="text-right font-medium text-slate-700 dark:text-slate-300">
+              Goal: ${goalAmount.toLocaleString()}
+            </p>
+          </div>
 
-            {/* Progress Bar Container */}
-            <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2.5 overflow-hidden">
+          <div className="space-y-2">
+            <div className="h-2.5 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
               <div
-                className="bg-gradient-to-r from-blue-500 to-cyan-400 h-2.5 rounded-full transition-all duration-1000 ease-out"
-                style={{ width: `${progressPercent}%` }}
+                className="h-full rounded-full bg-linear-to-r from-blue-500 to-cyan-400 transition-all duration-700"
+                style={{ width: `${progress}%` }}
               />
             </div>
-
-            {/* Footer Stats & Action */}
-            <div className="pt-4 space-y-4">
-              <div className="flex justify-between items-center text-xs text-slate-500 dark:text-slate-400 pt-2 border-t border-slate-200 dark:border-slate-700">
-                <div className="flex items-center space-x-1">
-                  <Users size={14} />
-                  <span>{contributorsCount} Contributors</span>
-                </div>
-                <div className="flex items-center space-x-1 text-blue-600 dark:text-cyan-400">
-                  <TrendingUp size={14} />
-                  <span className="font-semibold">
-                    {Math.round(progressPercent)}%
-                  </span>
-                </div>
-              </div>
-
-              {/* Donate Button */}
-              <Button
-                onClick={() => setIsModalOpen(true)}
-                className="w-full bg-slate-900 hover:bg-slate-800 dark:bg-white dark:hover:bg-slate-200 text-white dark:text-slate-900 transition-colors"
-              >
-                Donate Now
-              </Button>
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-semibold text-blue-600 dark:text-cyan-400">{Math.round(progress)}% funded</span>
+              <span className="flex items-center gap-1 text-slate-500 dark:text-slate-400">
+                <Users size={14} />
+                {donorCount} donors
+              </span>
             </div>
           </div>
-        </div>
-      </div>
-
-      <DonationModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        poolTitle={title}
-        poolId={poolId}
-        contractId={contractId}
-      />
-    </>
-  );
-};
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/frontend/src/components/PoolGrid.tsx
+++ b/frontend/src/components/PoolGrid.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { PoolCard, PoolCardProps } from "./PoolCard";
+import React from "react"
+import { PoolCard, PoolCardProps } from "./PoolCard"
 
 // Mock Data
 const MOCK_POOLS: PoolCardProps[] = [
@@ -8,86 +8,86 @@ const MOCK_POOLS: PoolCardProps[] = [
     title: "Clean Water Initiative",
     description:
       "Providing clean drinking water to remote villages. Every drop counts towards a healthier future.",
-    category: "Environment",
     imageUrl:
       "https://images.unsplash.com/photo-1541249591-6284fcdbf769?auto=format&fit=crop&q=80&w=800",
     goalAmount: 50000,
     raisedAmount: 32500,
-    contributorsCount: 142,
-    poolId: "pool_1",
-    contractId: "contract_1",
+    donorCount: 142,
+    creatorName: "Amina Yusuf",
+    creatorAvatarUrl: "https://i.pravatar.cc/120?img=48",
+    status: "Open",
   },
   {
     id: "2",
     title: "Tech Education for Girls",
     description:
       "Empowering young girls with coding skills and laptops to bridge the gender gap in tech.",
-    category: "Education",
     imageUrl:
       "https://images.unsplash.com/photo-1577896851231-70ef18881754?auto=format&fit=crop&q=80&w=800",
     goalAmount: 25000,
     raisedAmount: 22000,
-    contributorsCount: 89,
-    poolId: "pool_2",
-    contractId: "contract_2",
+    donorCount: 89,
+    creatorName: "Chloe Rivera",
+    creatorAvatarUrl: "https://i.pravatar.cc/120?img=16",
+    status: "Open",
   },
   {
     id: "3",
     title: "Urban Reforestation",
     description:
       "Planting trees in metropolitan areas to combat pollution and lower urban temperatures.",
-    category: "Environment",
     imageUrl:
       "https://images.unsplash.com/photo-1542601906990-b4d3fb778b09?auto=format&fit=crop&q=80&w=800",
     goalAmount: 15000,
     raisedAmount: 4500,
-    contributorsCount: 34,
-    poolId: "pool_3",
-    contractId: "contract_3",
+    donorCount: 34,
+    creatorName: "Mason Bennett",
+    creatorAvatarUrl: "https://i.pravatar.cc/120?img=67",
+    status: "Open",
   },
   {
     id: "4",
     title: "Healthcare Clinic Access",
     description:
       "Building a mobile clinic to reach under-served populations in rural communities.",
-    category: "Health",
     imageUrl:
       "https://images.unsplash.com/photo-1538108149393-fbbd81895907?auto=format&fit=crop&q=80&w=800",
     goalAmount: 100000,
     raisedAmount: 12000,
-    contributorsCount: 56,
-    poolId: "pool_4",
-    contractId: "contract_4",
+    donorCount: 56,
+    creatorName: "Sophia Kim",
+    creatorAvatarUrl: "https://i.pravatar.cc/120?img=47",
+    status: "Open",
   },
   {
     id: "5",
     title: "Local Arts Center Fund",
     description:
       "Supporting local artists and providing free art workshops for children after school.",
-    category: "Arts & Culture",
     imageUrl:
       "https://images.unsplash.com/photo-1460661419201-fd4cecdf8a8b?auto=format&fit=crop&q=80&w=800",
     goalAmount: 8000,
     raisedAmount: 7600,
-    contributorsCount: 205,
-    poolId: "pool_5",
-    contractId: "contract_5",
+    donorCount: 205,
+    creatorName: "Noah Thompson",
+    creatorAvatarUrl: "https://i.pravatar.cc/120?img=11",
+    status: "Closed",
   },
   {
     id: "6",
     title: "Disaster Relief Fund",
     description:
       "Emergency funding for immediate food, shelter, and medical supplies for victims of the recent hurricane.",
-    category: "Emergency",
     imageUrl:
       "https://images.unsplash.com/photo-1588680145224-811c751270ae?auto=format&fit=crop&q=80&w=800",
     goalAmount: 200000,
     raisedAmount: 150000,
-    contributorsCount: 890,
-    poolId: "pool_6",
-    contractId: "contract_6",
+    donorCount: 890,
+    creatorName: "Liam Ortiz",
+    creatorAvatarUrl: "https://i.pravatar.cc/120?img=31",
+    status: "Open",
   },
-];
+]
 
 export const PoolGrid: React.FC = () => {
   return (
@@ -96,5 +96,5 @@ export const PoolGrid: React.FC = () => {
         <PoolCard key={pool.id} {...pool} />
       ))}
     </div>
-  );
-};
+  )
+}

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,62 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "rounded-xl border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"h3">) {
+  return (
+    <h3
+      data-slot="card-title"
+      className={cn("font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="card-description"
+      className={cn("text-sm text-slate-600 dark:text-slate-400", className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-content" className={cn("p-6 pt-0", className)} {...props} />
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    />
+  )
+}
+
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }


### PR DESCRIPTION
Create a specialized PoolCard built on the shared Card base that shows pool progress, donor metrics, creator identity, and open/closed status. Add mock pool data integration and pool detail routing so cards navigate to dedicated pool pages.

Closes #393