### PR TITLE
fix: workflow bugs, corrupted test.rs, add tests for #472 and #491

### DIFF
--- a/.github/workflows/contract-build-ci.yml
+++ b/.github/workflows/contract-build-ci.yml
@@ -18,16 +18,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Stellar CLI
-        run: curl https://github.com/stellar/rs-soroban-sdk/releases/download/21.0.0/soroban-cli-21.0.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
-
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli --features opt
 
       - name: Build smart contract
         run: cargo build --release --target wasm32-unknown-unknown

--- a/nevo_contract/contracts/hello-world/src/test.rs
+++ b/nevo_contract/contracts/hello-world/src/test.rs
@@ -7,7 +7,6 @@ use soroban_sdk::{
     Address, Env, IntoVal, String, Vec,
 };
 
-/// Create a mock SAC token, mint `amount` into `recipient`, and return the token address.
 fn create_token(env: &Env, amount: i128, recipient: &Address) -> Address {
     let admin = Address::generate(env);
     let token = env.register_stellar_asset_contract_v2(admin.clone());
@@ -16,6 +15,8 @@ fn create_token(env: &Env, amount: i128, recipient: &Address) -> Address {
     token.address()
 }
 
+// ============= BASIC POOL TESTS =============
+
 #[test]
 fn test_create_pool() {
     let env = Env::default();
@@ -23,20 +24,20 @@ fn test_create_pool() {
     let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Emergency Relief Fund");
-    let description = String::from_str(&env, "Helping those in need");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Emergency Relief Fund"),
+        &String::from_str(&env, "Helping those in need"),
+        &1_000_000_000u128,
+    );
 
     assert_eq!(pool_id, 1);
-
     let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.0, 1); // id
-    assert_eq!(pool.1, creator); // creator
-    assert_eq!(pool.2, goal); // goal
-    assert_eq!(pool.3, 0); // collected
-    assert_eq!(pool.4, false); // is_closed
+    assert_eq!(pool.0, 1);
+    assert_eq!(pool.1, creator);
+    assert_eq!(pool.2, 1_000_000_000u128);
+    assert_eq!(pool.3, 0u128);
+    assert_eq!(pool.4, false);
 }
 
 #[test]
@@ -47,40 +48,16 @@ fn test_donate() {
 
     let creator = Address::generate(&env);
     let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Educational Scholarship");
-    let description = String::from_str(&env, "Support for students");
-    let goal: u128 = 10_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
-    let donation_amount: u128 = 100_000_000;
-    client.donate(&pool_id, &donor, &donation_amount);
-
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, donation_amount); // collected amount
-}
-
-#[test]
-fn test_apply_for_scholarship_creates_application() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-    let title = String::from_str(&env, "Scholarship Pool");
-    let description = String::from_str(&env, "Support for students");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
-    // Apply to pool
-    env.mock_all_auths();
-    client.apply_to_pool(
-        &pool_id,
-        &student,
-        &String::from_str(&env, "application_data"),
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Educational Scholarship"),
+        &String::from_str(&env, "Support for students"),
+        &10_000_000_000u128,
     );
+
+    client.donate(&pool_id, &donor, &100_000_000u128);
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.3, 100_000_000u128);
 }
 
 #[test]
@@ -90,19 +67,17 @@ fn test_multiple_donations() {
     let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let donor1 = Address::generate(&env);
-    let donor2 = Address::generate(&env);
-    let title = String::from_str(&env, "Community Project");
-    let description = String::from_str(&env, "Building together");
-    let goal: u128 = 5_000_000_000;
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Community Project"),
+        &String::from_str(&env, "Building together"),
+        &5_000_000_000u128,
+    );
 
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
-    client.donate(&pool_id, &donor1, &100_000_000);
-    client.donate(&pool_id, &donor2, &200_000_000);
-
+    client.donate(&pool_id, &Address::generate(&env), &100_000_000u128);
+    client.donate(&pool_id, &Address::generate(&env), &200_000_000u128);
     let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 300_000_000); // collected amount
+    assert_eq!(pool.3, 300_000_000u128);
 }
 
 #[test]
@@ -113,15 +88,15 @@ fn test_close_pool() {
     let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Closed Pool");
-    let description = String::from_str(&env, "Test pool");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Closed Pool"),
+        &String::from_str(&env, "Test pool"),
+        &1_000_000_000u128,
+    );
     client.close_pool(&pool_id);
-
     let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.4, true); // is_closed
+    assert_eq!(pool.4, true);
 }
 
 #[test]
@@ -133,15 +108,14 @@ fn test_donate_to_closed_pool() {
     let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Test Pool");
-    let description = String::from_str(&env, "Test");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Test Pool"),
+        &String::from_str(&env, "Test"),
+        &1_000_000_000u128,
+    );
     client.close_pool(&pool_id);
-
-    client.donate(&pool_id, &donor, &100_000_000);
+    client.donate(&pool_id, &Address::generate(&env), &100_000_000u128);
 }
 
 #[test]
@@ -153,13 +127,12 @@ fn test_close_pool_unauthorized() {
 
     let creator = Address::generate(&env);
     let unauthorized = Address::generate(&env);
-    let title = String::from_str(&env, "Test Pool");
-    let description = String::from_str(&env, "Test");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
-    // Try to close pool with unauthorized user - should panic
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Test Pool"),
+        &String::from_str(&env, "Test"),
+        &1_000_000_000u128,
+    );
     client
         .mock_auths(&[MockAuth {
             address: &unauthorized,
@@ -179,21 +152,17 @@ fn test_multiple_pools() {
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
-    let creator1 = Address::generate(&env);
-    let creator2 = Address::generate(&env);
-
     let pool_id_1 = client.create_pool(
-        &creator1,
+        &Address::generate(&env),
         &String::from_str(&env, "Pool 1"),
         &String::from_str(&env, "First pool"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
     let pool_id_2 = client.create_pool(
-        &creator2,
+        &Address::generate(&env),
         &String::from_str(&env, "Pool 2"),
         &String::from_str(&env, "Second pool"),
-        &2_000_000_000,
+        &2_000_000_000u128,
     );
 
     assert_eq!(pool_id_1, 1);
@@ -202,92 +171,12 @@ fn test_multiple_pools() {
 }
 
 #[test]
-fn test_get_pool_returns_existing_pool_config() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let goal: u128 = 2_500_000_000;
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Existing Pool"),
-        &String::from_str(&env, "Validation"),
-        &goal,
-    );
-
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool, (pool_id, creator, goal, 0, false));
-}
-
-#[test]
 #[should_panic(expected = "InvalidAction")]
 fn test_try_get_pool_returns_none_for_missing_pool() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
-
-    // try_get_pool will panic for non-existent pools
     let _missing_pool = client.try_get_pool(&999).unwrap();
-}
-
-#[test]
-fn test_try_get_pool_preserves_creation_parameters() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let goal: u128 = 9_000_000_000;
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Creation Parameters"),
-        &String::from_str(&env, "Must round-trip"),
-        &goal,
-    );
-
-    let pool = client.try_get_pool(&pool_id).unwrap().unwrap();
-    assert_eq!(pool, (pool_id, creator, goal, 0, false));
-}
-
-#[test]
-fn test_try_get_pool_retrieves_multiple_pools_independently() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator1 = Address::generate(&env);
-    let creator2 = Address::generate(&env);
-
-    let pool_id_1 = client.create_pool(
-        &creator1,
-        &String::from_str(&env, "Independent Pool 1"),
-        &String::from_str(&env, "First"),
-        &1_000_000_000,
-    );
-    let pool_id_2 = client.create_pool(
-        &creator2,
-        &String::from_str(&env, "Independent Pool 2"),
-        &String::from_str(&env, "Second"),
-        &3_000_000_000,
-    );
-
-    client.donate(&pool_id_1, &Address::generate(&env), &125_000_000);
-    client.donate(&pool_id_2, &Address::generate(&env), &275_000_000);
-
-    let pool1_result = client.try_get_pool(&pool_id_1).unwrap().unwrap();
-    assert_eq!(
-        pool1_result,
-        (pool_id_1, creator1, 1_000_000_000, 125_000_000, false)
-    );
-    
-    let pool2_result = client.try_get_pool(&pool_id_2).unwrap().unwrap();
-    assert_eq!(
-        pool2_result,
-        (pool_id_2, creator2, 3_000_000_000, 275_000_000, false)
-    );
 }
 
 #[test]
@@ -301,56 +190,9 @@ fn test_get_total_raised_starts_at_zero() {
         &creator,
         &String::from_str(&env, "Fresh Pool"),
         &String::from_str(&env, "No donations yet"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
     assert_eq!(client.get_total_raised(&pool_id), 0);
-}
-
-#[test]
-fn test_get_total_raised_tracks_single_and_multiple_donations() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor1 = Address::generate(&env);
-    let donor2 = Address::generate(&env);
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Raised Total"),
-        &String::from_str(&env, "Donation tracking"),
-        &2_000_000_000,
-    );
-
-    client.donate(&pool_id, &donor1, &100_000_000);
-    assert_eq!(client.get_total_raised(&pool_id), 100_000_000);
-
-    client.donate(&pool_id, &donor2, &250_000_000);
-    assert_eq!(client.get_total_raised(&pool_id), 350_000_000);
-}
-
-#[test]
-fn test_get_total_raised_matches_pool_balance() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Balance Match"),
-        &String::from_str(&env, "Compare accessors"),
-        &5_000_000_000,
-    );
-
-    client.donate(&pool_id, &donor, &400_000_000);
-
-    let total_raised = client.get_total_raised(&pool_id);
-    let pool = client.get_pool(&pool_id);
-
-    assert_eq!(total_raised, pool.3);
 }
 
 #[test]
@@ -359,11 +201,26 @@ fn test_get_total_raised_rejects_missing_pool() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
-
     let _ = client.get_total_raised(&999);
 }
 
-// ============= CLAIM_FUNDS TESTS =============
+#[test]
+#[should_panic(expected = "Description exceeds maximum length")]
+fn test_pool_description_exceeds_max_length() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let long_desc = String::from_str(&env, &"x".repeat(501));
+    client.create_pool(
+        &Address::generate(&env),
+        &String::from_str(&env, "Title"),
+        &long_desc,
+        &1_000_000_000u128,
+    );
+}
+
+// ============= CLAIM FUNDS TESTS =============
 
 #[test]
 #[should_panic(expected = "Application status not found")]
@@ -375,18 +232,15 @@ fn test_claim_funds_no_status() {
 
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-
-    client.claim_funds(&student, &pool_id, &100_000_000i128, &token_address);
+    client.donate(&pool_id, &creator, &500_000_000u128);
+    let token = Address::generate(&env);
+    client.claim_funds(&student, &pool_id, &100_000_000i128, &token);
 }
 
 #[test]
@@ -399,19 +253,16 @@ fn test_claim_funds_rejected_application() {
 
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &creator, &500_000_000);
+    client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Rejected"));
-
-    client.claim_funds(&student, &pool_id, &100_000_000i128, &token_address);
+    let token = Address::generate(&env);
+    client.claim_funds(&student, &pool_id, &100_000_000i128, &token);
 }
 
 #[test]
@@ -424,19 +275,16 @@ fn test_claim_funds_overdraw() {
 
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &creator, &100_000_000);
+    client.donate(&pool_id, &creator, &100_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    client.claim_funds(&student, &pool_id, &500_000_000i128, &token_address);
+    let token = Address::generate(&env);
+    client.claim_funds(&student, &pool_id, &500_000_000i128, &token);
 }
 
 #[test]
@@ -449,19 +297,16 @@ fn test_claim_funds_negative_amount() {
 
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &creator, &500_000_000);
+    client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    client.claim_funds(&student, &pool_id, &-100_000_000i128, &token_address);
+    let token = Address::generate(&env);
+    client.claim_funds(&student, &pool_id, &-100_000_000i128, &token);
 }
 
 #[test]
@@ -472,16 +317,13 @@ fn test_get_claimed_amount_initial_zero() {
 
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    let initial_claimed = client.get_claimed_amount(&pool_id, &student);
-    assert_eq!(initial_claimed, 0);
+    assert_eq!(client.get_claimed_amount(&pool_id, &student), 0);
 }
 
 #[test]
@@ -492,22 +334,18 @@ fn test_get_application_status() {
 
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
 
-    let initial_status = client.get_application_status(&pool_id, &student);
-    assert_eq!(initial_status, String::from_str(&env, ""));
+    assert_eq!(client.get_application_status(&pool_id, &student), String::from_str(&env, ""));
 
-    let approved_status = String::from_str(&env, "Approved");
-    client.set_application_status(&pool_id, &student, &approved_status);
-
-    let status_after_set = client.get_application_status(&pool_id, &student);
-    assert_eq!(status_after_set, approved_status);
+    let approved = String::from_str(&env, "Approved");
+    client.set_application_status(&pool_id, &student, &approved);
+    assert_eq!(client.get_application_status(&pool_id, &student), approved);
 }
 
 // ============= PROTOCOL FEES TESTS =============
@@ -522,31 +360,20 @@ fn test_protocol_fees_accumulation_on_claim() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-
-    // Create a real SAC token and fund the contract so it can transfer
     let claim_amount: i128 = 100_000_000;
-    let token_address = create_token(&env, claim_amount, &contract_id);
+    let token = create_token(&env, claim_amount, &contract_id);
 
-    // Set admin
     client.set_admin(&admin);
-
-    // Create pool and donate
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-
-    // Approve student and allow them to claim
+    client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
+    client.claim_funds(&student, &pool_id, &claim_amount, &token);
 
-    // Student claims funds - should accumulate 1% fee
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-
-    // Verify application recorded the claim
     let app = client.get_application(&pool_id, &student);
     assert!(app.is_some());
 }
@@ -561,13 +388,9 @@ fn test_claim_protocol_fees_requires_admin_authorization() {
 
     let admin = Address::generate(&env);
     let non_admin = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    // Set admin
+    let token = Address::generate(&env);
     client.set_admin(&admin);
-
-    // Try to claim as non-admin - should panic
-    client.claim_protocol_fees(&non_admin, &token_address);
+    client.claim_protocol_fees(&non_admin, &token);
 }
 
 #[test]
@@ -579,13 +402,9 @@ fn test_claim_protocol_fees_no_fees() {
     let client = ContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    // Set admin
+    let token = Address::generate(&env);
     client.set_admin(&admin);
-
-    // Try to claim when no fees accumulated - should panic
-    client.claim_protocol_fees(&admin, &token_address);
+    client.claim_protocol_fees(&admin, &token);
 }
 
 #[test]
@@ -599,83 +418,25 @@ fn test_claim_protocol_fees_multiple_claims_accumulate() {
     let creator = Address::generate(&env);
     let student1 = Address::generate(&env);
     let student2 = Address::generate(&env);
+    let claim1: i128 = 100_000_000;
+    let claim2: i128 = 50_000_000;
+    let token = create_token(&env, claim1 + claim2, &contract_id);
 
-    // Total needed by contract: claim1 + claim2 = 150_000_000
-    // net to students: 99_000_000 + 49_500_000; fees: 1_000_000 + 500_000
-    let claim_amount1: i128 = 100_000_000;
-    let claim_amount2: i128 = 50_000_000;
-    let token_address = create_token(&env, claim_amount1 + claim_amount2, &contract_id);
-
-    // Set admin
     client.set_admin(&admin);
-
-    // Create pool with sufficient funds
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-
-    // Approve students
+    client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student1, &String::from_str(&env, "Approved"));
     client.set_application_status(&pool_id, &student2, &String::from_str(&env, "Approved"));
+    client.claim_funds(&student1, &pool_id, &claim1, &token);
+    client.claim_funds(&student2, &pool_id, &claim2, &token);
 
-    // Multiple students claim - each generates 1% fee
-    client.claim_funds(&student1, &pool_id, &claim_amount1, &token_address);
-    client.claim_funds(&student2, &pool_id, &claim_amount2, &token_address);
-
-    // Admin claims accumulated fees
-    // Expected: (100_000_000 / 100) + (50_000_000 / 100) = 1_000_000 + 500_000 = 1_500_000
-    let collected_fees = client.claim_protocol_fees(&admin, &token_address);
-
-    assert_eq!(collected_fees, 1_500_000);
-}
-
-#[test]
-fn test_fees_isolated_from_student_allocations() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let claim_amount: i128 = 100_000_000;
-    // Fund the contract with enough tokens to cover the transfer
-    let token_address = create_token(&env, claim_amount, &contract_id);
-
-    // Set admin
-    client.set_admin(&admin);
-
-    // Create pool
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test Pool"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    let donated_amount: u128 = 500_000_000;
-    client.donate(&pool_id, &creator, &donated_amount);
-
-    // Approve student
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Student claims
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-
-    // Verify student application amount_claimed is correct (not affected by fees)
-    let app = client.get_application(&pool_id, &student);
-    assert!(app.is_some());
-    let app_unwrapped = app.unwrap();
-
-    // amount_claimed should be exactly the claim_amount, fees are tracked separately
-    assert_eq!(app_unwrapped.amount_claimed, claim_amount);
+    let fees = client.claim_protocol_fees(&admin, &token);
+    assert_eq!(fees, 1_500_000); // 1% of 100M + 1% of 50M
 }
 
 #[test]
@@ -689,120 +450,24 @@ fn test_protocol_fees_reset_after_claim() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-
     let claim_amount: i128 = 100_000_000;
-    // Mint enough for student transfer AND for fee payout to admin later
-    // net_transfer = claim_amount - fee = 99_000_000; fee = 1_000_000
-    // total needed: 100_000_000 (student net 99M + fee held 1M)
-    let token_address = create_token(&env, claim_amount, &contract_id);
+    let token = create_token(&env, claim_amount, &contract_id);
 
-    // Set admin
     client.set_admin(&admin);
-
-    // Create pool and donate
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-
-    // Approve student
+    client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Student claims - net goes to student, 1% fee stays in contract
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-
-    // Admin claims fees - transfers the 1_000_000 fee out
-    let _fees = client.claim_protocol_fees(&admin, &token_address);
-
-    // Try to claim again - should panic (no fees accumulated)
-    client.claim_protocol_fees(&admin, &token_address);
+    client.claim_funds(&student, &pool_id, &claim_amount, &token);
+    client.claim_protocol_fees(&admin, &token);
+    // Second claim should panic
+    client.claim_protocol_fees(&admin, &token);
 }
 
-// ============= DOCUMENTATION TESTS =============
-// These tests verify that documentation accurately describes function behavior,
-// error conditions, parameters, return values, and usage examples.
-
-/// DOC TEST 1: create_pool documentation accuracy
-/// Verifies: Function behavior, parameter requirements, return value
-#[test]
-fn test_doc_create_pool_behavior_matches_docs() {
-// ============= RECOVERY SCENARIO TESTS =============
-
-/// Test 1: Failed operations don't corrupt state
-/// Verify that when a donation to a closed pool fails, the pool state remains unchanged
-/// This test verifies state is preserved by checking pool state before and after closing
-#[test]
-fn test_recovery_failed_donation_preserves_state() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Test Pool");
-    let description = String::from_str(&env, "Documentation test");
-    let goal: u128 = 1_000_000_000;
-
-    // Doc states: "Create a new donation / sponsorship pool"
-    // Returns: pool_id (u32)
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    
-    // Verify return value is u32 and sequential
-    assert_eq!(pool_id, 1);
-    
-    // Verify pool is created with correct initial state
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.0, pool_id); // id matches
-    assert_eq!(pool.1, creator); // creator matches
-    assert_eq!(pool.2, goal); // goal matches
-    assert_eq!(pool.3, 0); // collected starts at 0
-    assert_eq!(pool.4, false); // is_closed starts as false
-}
-
-/// DOC TEST 2: donate documentation accuracy
-/// Verifies: Function behavior, error conditions documented
-#[test]
-fn test_doc_donate_behavior_matches_docs() {
-    let env = Env::default();
-    let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Recovery Test Pool");
-    let description = String::from_str(&env, "State preservation test");
-    let goal: u128 = 1_000_000_000;
-
-    // Create pool and make initial donation
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    client.donate(&pool_id, &donor, &100_000_000);
-
-    // Capture state before closing
-    let pool_before = client.get_pool(&pool_id);
-    let collected_before = pool_before.3;
-
-    // Close the pool
-    client
-        .mock_auths(&[MockAuth {
-            address: &creator,
-            invoke: &MockAuthInvoke {
-                contract: &contract_id,
-                fn_name: "close_pool",
-                args: (&pool_id,).into_val(&env),
-                sub_invokes: &[],
-            },
-        }])
-        .close_pool(&pool_id);
-
-    // Verify state after closing - collected amount unchanged, pool is closed
-    let pool_after = client.get_pool(&pool_id);
-    assert_eq!(pool_after.3, collected_before); // collected amount unchanged
-    assert_eq!(pool_after.4, true); // now closed
-}
-
-/// Test 2: Partial failures handled cleanly - multiple operations with one failure
-/// Verify that when one claim fails, other valid claims still succeed
-#[test]
-fn test_recovery_partial_failure_isolation() {
 // ============= DONOR COUNT TRACKING TESTS =============
 
 #[test]
@@ -816,29 +481,9 @@ fn test_new_campaign_has_zero_donors() {
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Description"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
     assert_eq!(client.get_donor_count(&pool_id), 0);
-}
-
-#[test]
-fn test_first_donation_increments_count_to_one() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test Pool"),
-        &String::from_str(&env, "Description"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &donor, &100_000_000);
-    assert_eq!(client.get_donor_count(&pool_id), 1);
 }
 
 #[test]
@@ -853,11 +498,10 @@ fn test_same_donor_multiple_donations_keeps_count_at_one() {
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Description"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &donor, &100_000_000);
-    client.donate(&pool_id, &donor, &200_000_000);
+    client.donate(&pool_id, &donor, &100_000_000u128);
+    client.donate(&pool_id, &donor, &200_000_000u128);
     assert_eq!(client.get_donor_count(&pool_id), 1);
 }
 
@@ -868,103 +512,25 @@ fn test_different_donors_increment_count_correctly() {
     let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let donor1 = Address::generate(&env);
-    let donor2 = Address::generate(&env);
-    let donor3 = Address::generate(&env);
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Description"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &donor1, &100_000_000);
-    client.donate(&pool_id, &donor2, &200_000_000);
-    client.donate(&pool_id, &donor3, &300_000_000);
+    client.donate(&pool_id, &Address::generate(&env), &100_000_000u128);
+    client.donate(&pool_id, &Address::generate(&env), &200_000_000u128);
+    client.donate(&pool_id, &Address::generate(&env), &300_000_000u128);
     assert_eq!(client.get_donor_count(&pool_id), 3);
 }
 
 #[test]
 #[should_panic(expected = "Pool not found")]
-fn test_nonexistent_campaign_returns_error() {
+fn test_donor_count_nonexistent_pool() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
-
-    // Attempt to get donor count for a pool that doesn't exist
     client.get_donor_count(&999u32);
-}
-
-// ============= CONTRIBUTIONS GETTER VALIDATION TESTS =============
-
-#[test]
-fn test_contributor_with_no_donations_returns_zero() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test Pool"),
-        &String::from_str(&env, "Description"),
-        &1_000_000_000,
-    );
-
-    assert_eq!(client.get_contribution(&pool_id, &donor), 0);
-}
-
-#[test]
-fn test_contributor_with_multiple_donations_returns_sum() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test Pool"),
-        &String::from_str(&env, "Description"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &donor, &100_000_000);
-    client.donate(&pool_id, &donor, &200_000_000);
-    client.donate(&pool_id, &donor, &50_000_000);
-    assert_eq!(client.get_contribution(&pool_id, &donor), 350_000_000);
-}
-
-#[test]
-fn test_nonexistent_contributor_returns_zero() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let existing_donor = Address::generate(&env);
-    let nonexistent_donor = Address::generate(&env);
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test Pool"),
-        &String::from_str(&env, "Description"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &existing_donor, &100_000_000);
-    assert_eq!(client.get_contribution(&pool_id, &nonexistent_donor), 0);
-}
-
-#[test]
-#[should_panic(expected = "Pool not found")]
-fn test_nonexistent_campaign_returns_campaign_not_found() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let donor = Address::generate(&env);
-    client.get_contribution(&999u32, &donor);
 }
 
 #[test]
@@ -981,538 +547,66 @@ fn test_multiple_contributors_tracked_separately() {
         &creator,
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Description"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    client.donate(&pool_id, &donor1, &100_000_000);
-    client.donate(&pool_id, &donor2, &200_000_000);
-    client.donate(&pool_id, &donor3, &300_000_000);
-
-    assert_eq!(client.get_contribution(&pool_id, &donor1), 100_000_000);
-    assert_eq!(client.get_contribution(&pool_id, &donor2), 200_000_000);
-    assert_eq!(client.get_contribution(&pool_id, &donor3), 300_000_000);
+    client.donate(&pool_id, &donor1, &100_000_000u128);
+    client.donate(&pool_id, &donor2, &200_000_000u128);
+    client.donate(&pool_id, &donor3, &300_000_000u128);
+    assert_eq!(client.get_contribution(&pool_id, &donor1), 100_000_000u128);
+    assert_eq!(client.get_contribution(&pool_id, &donor2), 200_000_000u128);
+    assert_eq!(client.get_contribution(&pool_id, &donor3), 300_000_000u128);
 }
 
-// ============= ISSUE #515: FUNCTION PARAMETER VALIDATION TESTS =============
+// ============= SCHOOL & APPLICATION TESTS =============
 
-// (1) Out-of-range / zero values caught
 #[test]
-#[should_panic(expected = "Claim amount must be positive")]
-fn test_claim_funds_zero_amount_rejected() {
+fn test_register_school_and_create_pool_for_school() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
+    let school = Address::generate(&env);
     let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    
-    let pool_id = client.create_pool(
+
+    client.set_admin(&admin);
+    client.register_school(&admin, &school);
+    assert!(client.is_school_registered(&school));
+
+    let pool_id = client.create_pool_for_school(
         &creator,
+        &String::from_str(&env, "School Pool"),
         &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &1_000_000_000u128,
+        &school,
     );
-
-    // Doc states: "Donate to an existing pool"
-    // Should update collected amount
-    client.donate(&pool_id, &donor, &100_000_000);
-    
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 100_000_000); // collected updated
+    assert_eq!(pool_id, 1);
+    assert_eq!(client.get_pool_school(&pool_id), school);
 }
 
-/// DOC TEST 3: donate error condition - closed pool
-/// Verifies: Error conditions documented (panics with "Pool is closed")
-#[test]
-#[should_panic(expected = "Pool is closed")]
-fn test_doc_donate_error_pool_closed() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    // Close the pool
-    client.mock_auths(&[MockAuth {
-        address: &creator,
-        invoke: &MockAuthInvoke {
-            contract: &contract_id,
-            fn_name: "close_pool",
-            args: (&pool_id,).into_val(&env),
-            sub_invokes: &[],
-        },
-    }]).close_pool(&pool_id);
-
-    // Doc states: panics with "Pool is closed" when donating to closed pool
-    client.donate(&pool_id, &donor, &100_000_000);
-}
-
-/// DOC TEST 4: donate error condition - pool not found
-/// Verifies: Error conditions documented
-#[test]
-#[should_panic(expected = "Pool not found")]
-fn test_doc_donate_error_pool_not_found() {
-    let student1 = Address::generate(&env);
-    let student3 = Address::generate(&env);
-
-    // Create pool with sufficient funds
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Partial Failure Test"),
-        &String::from_str(&env, "Test isolation"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-
-    // Approve two students
-    client.set_application_status(&pool_id, &student1, &String::from_str(&env, "Approved"));
-    client.set_application_status(&pool_id, &student3, &String::from_str(&env, "Approved"));
-
-    let claim_amount: i128 = 50_000_000;
-    let token_address = create_token(&env, claim_amount * 2, &contract_id);
-
-    // Student1 claims successfully
-    client.claim_funds(&student1, &pool_id, &claim_amount, &token_address);
-    let app1 = client.get_application(&pool_id, &student1);
-    assert!(app1.is_some());
-    assert_eq!(app1.unwrap().amount_claimed, claim_amount);
-
-    // Student3 can still claim (operations are isolated)
-    client.claim_funds(&student3, &pool_id, &claim_amount, &token_address);
-    let app3 = client.get_application(&pool_id, &student3);
-    assert!(app3.is_some());
-    assert_eq!(app3.unwrap().amount_claimed, claim_amount);
-}
-
-/// Test 3: System recoverable after errors - pool can continue after failed operations
-#[test]
-fn test_recovery_system_continues_after_error() {
-    let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool"),
-        &String::from_str(&env, "Desc"),
-        &1_000_000_000,
-    );
-    client.donate(&pool_id, &creator, &500_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Zero is not positive — must be rejected
-    client.claim_funds(&student, &pool_id, &0i128, &token_address);
-}
-
-// (2) Invalid pool_id (non-existent) rejected with specific message
-#[test]
-#[should_panic(expected = "Pool not found")]
-fn test_get_pool_invalid_id_rejected() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let donor = Address::generate(&env);
-    
-    // Doc states: panics with "Pool not found" for non-existent pool
-    client.donate(&999, &donor, &100_000_000);
-}
-
-/// DOC TEST 5: get_pool documentation accuracy
-/// Verifies: Return value specifications accurate
-#[test]
-fn test_doc_get_pool_return_value_accurate() {
-    // Pool 999 was never created
-    client.get_pool(&999u32);
-}
-
-// (3) donate to non-existent pool rejected
-#[test]
-#[should_panic(expected = "Pool not found")]
-fn test_donate_invalid_pool_id_rejected() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let goal: u128 = 5_000_000_000;
-    
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &goal,
-    );
-
-    // Doc states: "Get pool information as a tuple (id, creator, goal, collected, is_closed)"
-    let pool = client.get_pool(&pool_id);
-    
-    // Verify tuple structure matches documentation
-    assert_eq!(pool.0, pool_id); // id
-    assert_eq!(pool.1, creator); // creator
-    assert_eq!(pool.2, goal); // goal
-    assert_eq!(pool.3, 0); // collected
-    assert_eq!(pool.4, false); // is_closed
-}
-
-/// DOC TEST 6: close_pool documentation accuracy
-/// Verifies: Function behavior and authorization requirements
-#[test]
-fn test_doc_close_pool_behavior_matches_docs() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    // Doc states: "Close a donation pool" - requires creator authorization
-    client.mock_auths(&[MockAuth {
-        address: &creator,
-        invoke: &MockAuthInvoke {
-            contract: &contract_id,
-            fn_name: "close_pool",
-            args: (&pool_id,).into_val(&env),
-            sub_invokes: &[],
-        },
-    }]).close_pool(&pool_id);
-
-    // Verify pool is closed
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.4, true); // is_closed is true
-}
-
-/// DOC TEST 7: get_pool_count documentation accuracy
-/// Verifies: Return value accurate
-#[test]
-fn test_doc_get_pool_count_return_value_accurate() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    // Doc states: "Get the total number of pools"
-    // Initially should be 0
-    assert_eq!(client.get_pool_count(), 0);
-
-    let creator = Address::generate(&env);
-    
-    // Create first pool
-    client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool 1"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-    assert_eq!(client.get_pool_count(), 1);
-
-    // Create second pool
-    client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool 2"),
-        &String::from_str(&env, "Test"),
-        &2_000_000_000,
-    );
-    assert_eq!(client.get_pool_count(), 2);
-}
-
-/// DOC TEST 8: claim_funds documentation accuracy - all documented panics
-/// Verifies: All error conditions documented in claim_funds
-#[test]
-#[should_panic(expected = "Claim amount must be positive")]
-fn test_doc_claim_funds_error_negative_amount() {
-    let donor = Address::generate(&env);
-
-    // Create pool
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Recovery Pool"),
-        &String::from_str(&env, "System recovery test"),
-        &1_000_000_000,
-    );
-
-    // Make initial donation
-    client.donate(&pool_id, &donor, &100_000_000);
-
-    // Verify system is still operational - can continue with valid operations
-    client.donate(&pool_id, &donor, &50_000_000);
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 150_000_000); // Total collected
-
-    // Can still create new pools
-    let pool_id_2 = client.create_pool(
-        &creator,
-        &String::from_str(&env, "New Pool After Error"),
-        &String::from_str(&env, "Recovery verified"),
-        &2_000_000_000,
-    );
-    assert_eq!(pool_id_2, 2);
-}
-
-/// Test 4: Rollback mechanisms work - failed claim doesn't update state
-#[test]
-#[should_panic(expected = "Overdraw attempt")]
-fn test_recovery_rollback_on_overdraw() {
-    let donor = Address::generate(&env);
-    client.donate(&999u32, &donor, &100_000_000);
-}
-
-// (4) apply_to_pool on non-existent pool rejected
-#[test]
-#[should_panic(expected = "Pool not found")]
-fn test_apply_to_pool_invalid_pool_id_rejected() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Doc states: Panics with "Claim amount must be positive" if claim_amount <= 0
-    client.claim_funds(&student, &pool_id, &0i128, &token_address);
-}
-
-/// DOC TEST 9: claim_funds error - application status not found
-#[test]
-#[should_panic(expected = "Application status not found")]
-fn test_doc_claim_funds_error_no_status() {
-
-    // Create pool with limited funds
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Rollback Test"),
-        &String::from_str(&env, "Test rollback"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &100_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    let token_address = Address::generate(&env);
-
-    // Attempt to claim more than available (should panic with "Overdraw attempt")
-    client.claim_funds(&student, &pool_id, &500_000_000i128, &token_address);
-}
-
-/// Test 4b: Verify state unchanged after overdraw attempt
-#[test]
-fn test_recovery_state_after_overdraw() {
-    let student = Address::generate(&env);
-    client.apply_to_pool(&999u32, &student, &String::from_str(&env, "data"));
-}
-
-// (5) Duplicate application rejected
-#[test]
-#[should_panic(expected = "Duplicate application")]
-fn test_apply_to_pool_duplicate_rejected() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-
-    // Doc states: Panics with "Application status not found" if no status has been set
-    client.claim_funds(&student, &pool_id, &100_000_000i128, &token_address);
-}
-
-/// DOC TEST 10: claim_funds error - application not approved
-#[test]
-#[should_panic(expected = "Application is not approved")]
-fn test_doc_claim_funds_error_not_approved() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Pending"));
-
-    // Doc states: Panics with "Application is not approved" if status != "Approved"
-    client.claim_funds(&student, &pool_id, &100_000_000i128, &token_address);
-}
-
-/// DOC TEST 11: claim_funds error - overdraw attempt
-#[test]
-#[should_panic(expected = "Overdraw attempt")]
-fn test_doc_claim_funds_error_overdraw() {
-
-    // Create pool with limited funds
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Rollback Test"),
-        &String::from_str(&env, "Test rollback"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &100_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Verify no claim has been made yet
-    let claimed = client.get_claimed_amount(&pool_id, &student);
-    assert_eq!(claimed, 0);
-
-    // Verify pool collected amount unchanged
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 100_000_000);
-}
-
-/// Test 5: Rollback on unauthorized close pool attempt
-#[test]
-fn test_recovery_rollback_unauthorized_close() {
-    let env = Env::default();
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool"),
-        &String::from_str(&env, "Desc"),
-        &1_000_000_000,
-    );
-
-    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
-    // Second application from same student must be rejected
-    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
-}
-
-// (6) create_pool_for_school with unregistered school rejected
 #[test]
 #[should_panic(expected = "School is not registered")]
-fn test_create_pool_for_school_unregistered_school_rejected() {
+fn test_create_pool_for_unregistered_school_fails() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &100_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Doc states: Panics with "Overdraw attempt" if amount_claimed + claim_amount > collected
-    client.claim_funds(&student, &pool_id, &200_000_000i128, &token_address);
-}
-
-/// DOC TEST 12: claim_protocol_fees documentation accuracy
-/// Verifies: Function behavior, authorization, and error conditions
-#[test]
-#[should_panic(expected = "Unauthorized admin")]
-fn test_doc_claim_protocol_fees_error_unauthorized() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    let non_admin = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    client.set_admin(&admin);
-
-    // Doc states: Panics with "Unauthorized admin" if caller is not the stored admin
-    client.claim_protocol_fees(&non_admin, &token_address);
-}
-
-/// DOC TEST 13: claim_protocol_fees error - no unclaimed fees
-#[test]
-#[should_panic(expected = "No unclaimed fees")]
-fn test_doc_claim_protocol_fees_error_no_fees() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    client.set_admin(&admin);
-
-    // Doc states: Panics with "No unclaimed fees" if there are no accumulated fees
-    client.claim_protocol_fees(&admin, &token_address);
-}
-
-/// DOC TEST 14: set_admin documentation accuracy
-/// Verifies: Function behavior and authorization requirements
-#[test]
-fn test_doc_set_admin_behavior_matches_docs() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-
-    // Doc states: "Set the platform admin address" - requires admin authorization
-    client.set_admin(&admin);
-
-    // Verify admin was set by trying to register a school
     let school = Address::generate(&env);
-    client.register_school(&admin, &school);
-    
-    // Verify school was registered
-    assert!(client.is_school_registered(&school));
+    client.create_pool_for_school(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+        &school,
+    );
 }
 
-/// DOC TEST 15: register_school documentation accuracy
-/// Verifies: Function behavior and error conditions
 #[test]
 #[should_panic(expected = "Admin not set")]
-fn test_doc_register_school_error_admin_not_set() {
+fn test_register_school_without_admin_set() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
@@ -1520,15 +614,12 @@ fn test_doc_register_school_error_admin_not_set() {
 
     let admin = Address::generate(&env);
     let school = Address::generate(&env);
-
-    // Doc states: Expects "Admin not set" if admin hasn't been set
     client.register_school(&admin, &school);
 }
 
-/// DOC TEST 16: register_school error - unauthorized admin
 #[test]
 #[should_panic(expected = "Unauthorized admin")]
-fn test_doc_register_school_error_unauthorized() {
+fn test_register_school_wrong_admin() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
@@ -1537,17 +628,64 @@ fn test_doc_register_school_error_unauthorized() {
     let admin = Address::generate(&env);
     let wrong_admin = Address::generate(&env);
     let school = Address::generate(&env);
-
     client.set_admin(&admin);
-
-    // Doc states: Panics with "Unauthorized admin" if caller is not the stored admin
     client.register_school(&wrong_admin, &school);
 }
 
-/// DOC TEST 17: is_school_registered documentation accuracy
-/// Verifies: Return value specifications accurate
 #[test]
-fn test_doc_is_school_registered_return_value_accurate() {
+fn test_apply_to_pool_creates_application() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Scholarship Pool"),
+        &String::from_str(&env, "Support for students"),
+        &1_000_000_000u128,
+    );
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "application_data"));
+    let status = client.get_application_status(&pool_id, &student);
+    assert_eq!(status, String::from_str(&env, "Pending"));
+}
+
+#[test]
+#[should_panic(expected = "Duplicate application")]
+fn test_duplicate_application_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+    );
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
+}
+
+#[test]
+#[should_panic(expected = "Pool not found")]
+fn test_apply_to_nonexistent_pool_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let student = Address::generate(&env);
+    client.apply_to_pool(&999u32, &student, &String::from_str(&env, "data"));
+}
+
+#[test]
+fn test_approve_application() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
@@ -1555,83 +693,81 @@ fn test_doc_is_school_registered_return_value_accurate() {
 
     let admin = Address::generate(&env);
     let school = Address::generate(&env);
-
-    client.set_admin(&admin);
-
-    // Doc states: "Check if a school has been registered" - returns bool
-    // Before registration, should return false
-    assert_eq!(client.is_school_registered(&school), false);
-
-    // After registration, should return true
-    client.register_school(&admin, &school);
-    assert_eq!(client.is_school_registered(&school), true);
-}
-
-/// DOC TEST 18: create_pool_for_school documentation accuracy
-/// Verifies: Function behavior and error conditions
-#[test]
-#[should_panic(expected = "School is not registered")]
-fn test_doc_create_pool_for_school_error_not_registered() {
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Auth Test Pool"),
-        &String::from_str(&env, "Test auth"),
-        &1_000_000_000,
-    );
-
-    // Capture initial state
-    let pool_before = client.get_pool(&pool_id);
-    assert_eq!(pool_before.4, false); // not closed
-
-    // After any failed authorization, pool should still be open
-    let pool_after = client.get_pool(&pool_id);
-    assert_eq!(pool_after.4, false); // still not closed
-}
-
-/// Test 6: Graceful degradation - system handles missing data gracefully
-#[test]
-fn test_recovery_graceful_degradation_missing_data() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
+    let creator = Address::generate(&env);
     let student = Address::generate(&env);
 
-    // Query application status for non-existent application (returns empty string)
-    let status = client.get_application_status(&999, &student);
-    assert_eq!(status, String::from_str(&env, ""));
-
-    // Query claimed amount for non-existent claim (returns 0)
-    let claimed = client.get_claimed_amount(&999, &student);
-    assert_eq!(claimed, 0);
-
-    // System remains operational after graceful failures
-    let creator = Address::generate(&env);
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Post-Degradation Pool"),
-        &String::from_str(&env, "Still works"),
-        &1_000_000_000,
-    );
-    assert_eq!(pool_id, 1);
-}
-
-/// Test 7: State consistency after multiple failed operations
-#[test]
-fn test_recovery_state_consistency_multiple_failures() {
-    let unregistered_school = Address::generate(&env);
-
-    client.create_pool_for_school(
+    client.set_admin(&admin);
+    client.register_school(&admin, &school);
+    let pool_id = client.create_pool_for_school(
         &creator,
         &String::from_str(&env, "Pool"),
         &String::from_str(&env, "Desc"),
-        &1_000_000_000,
-        &unregistered_school,
+        &1_000_000_000u128,
+        &school,
+    );
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
+    client.approve_application(&pool_id, &school, &student, &true);
+    assert_eq!(
+        client.get_application_status(&pool_id, &student),
+        String::from_str(&env, "Approved")
     );
 }
 
-// (7) setup_application_milestones with empty milestones rejected
+#[test]
+#[should_panic(expected = "Only linked school can approve")]
+fn test_wrong_school_cannot_approve() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let school1 = Address::generate(&env);
+    let school2 = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.register_school(&admin, &school1);
+    client.register_school(&admin, &school2);
+    let pool_id = client.create_pool_for_school(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+        &school1,
+    );
+    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
+    client.approve_application(&pool_id, &school2, &student, &true);
+}
+
+#[test]
+#[should_panic(expected = "Student has not applied")]
+fn test_approve_unapplied_student_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let school = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let student = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.register_school(&admin, &school);
+    let pool_id = client.create_pool_for_school(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+        &school,
+    );
+    client.approve_application(&pool_id, &school, &student, &true);
+}
+
+// ============= MILESTONE TESTS =============
+
 #[test]
 #[should_panic(expected = "Milestones required")]
 fn test_setup_milestones_empty_rejected() {
@@ -1640,41 +776,18 @@ fn test_setup_milestones_empty_rejected() {
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
-    let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
-    let school = Address::generate(&env);
-
-    client.set_admin(&admin);
-
-    // Doc states: Panics with "School is not registered" for unregistered school
-    client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-        &school,
-    );
-}
-
-/// DOC TEST 19: create_pool_for_school success case
-/// Verifies: Function behavior matches documentation
-#[test]
-fn test_doc_create_pool_for_school_behavior_matches_docs() {
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Pool"),
         &String::from_str(&env, "Desc"),
-        &1_000_000_000,
+        &1_000_000_000u128,
     );
-
-    let empty: soroban_sdk::Vec<Milestone> = soroban_sdk::Vec::new(&env);
+    let empty: Vec<Milestone> = Vec::new(&env);
     client.setup_application_milestones(&pool_id, &student, &empty);
 }
 
-// (8) setup_application_milestones where sum != goal rejected
 #[test]
 #[should_panic(expected = "Milestone total must equal pool goal")]
 fn test_setup_milestones_wrong_sum_rejected() {
@@ -1683,428 +796,21 @@ fn test_setup_milestones_wrong_sum_rejected() {
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
-    let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
-    let school = Address::generate(&env);
-
-    client.set_admin(&admin);
-    client.register_school(&admin, &school);
-
-    // Doc states: "Create a new sponsorship pool linked to a registered school"
-    let pool_id = client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "School Pool"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-        &school,
-    );
-
-    // Verify pool was created
-    assert_eq!(pool_id, 1);
-
-    // Verify school is linked to pool
-    let linked_school = client.get_pool_school(&pool_id);
-    assert_eq!(linked_school, school);
-}
-
-/// DOC TEST 20: get_pool_school documentation accuracy
-/// Verifies: Return value and error conditions
-#[test]
-#[should_panic(expected = "Pool school not set")]
-fn test_doc_get_pool_school_error_not_set() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    // Doc states: Expects "Pool school not set" for pools not linked to schools
-    client.get_pool_school(&pool_id);
-}
-
-/// DOC TEST 21: apply_to_pool documentation accuracy
-/// Verifies: Function behavior and error conditions
-#[test]
-#[should_panic(expected = "Pool not found")]
-fn test_doc_apply_to_pool_error_pool_not_found() {
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Consistency Test"),
-        &String::from_str(&env, "Multiple failures"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &200_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Verify state remains consistent - no corruption
-    let claimed = client.get_claimed_amount(&pool_id, &student);
-    assert_eq!(claimed, 0);
-
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 200_000_000); // collected unchanged
-}
-
-/// Test 8: Recovery from protocol fee claim failures
-#[test]
-fn test_recovery_protocol_fees_failure_handling() {
-    let goal: u128 = 1_000_000_000;
-
     let pool_id = client.create_pool(
         &creator,
         &String::from_str(&env, "Pool"),
         &String::from_str(&env, "Desc"),
-        &goal,
+        &1_000_000_000u128,
     );
-
-    let mut milestones: soroban_sdk::Vec<Milestone> = soroban_sdk::Vec::new(&env);
-    milestones.push_back(Milestone { amount: 500_000_000 }); // sum != goal
-    client.setup_application_milestones(&pool_id, &student, &milestones);
-}
-
-// ============= ISSUE #506: ERROR MESSAGE ACCURACY TESTS =============
-
-// (1) Specific error for missing admin (not generic)
-#[test]
-#[should_panic(expected = "Admin not set")]
-fn test_register_school_without_admin_set_gives_specific_error() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let student = Address::generate(&env);
-
-    // Doc states: Expects "Pool not found" for non-existent pool
-    client.apply_to_pool(
-        &999,
-        &student,
-        &String::from_str(&env, "Application"),
-    );
-}
-
-/// DOC TEST 22: apply_to_pool error - duplicate application
-#[test]
-#[should_panic(expected = "Duplicate application")]
-fn test_doc_apply_to_pool_error_duplicate() {
-    let admin = Address::generate(&env);
-
-    client.set_admin(&admin);
-
-    // System should still be operational - can set admin again
-    let new_admin = Address::generate(&env);
-    client.set_admin(&new_admin);
-}
-
-/// Test 9: Graceful handling of duplicate application attempts
-#[test]
-#[should_panic(expected = "Duplicate application")]
-fn test_recovery_duplicate_application_prevention() {
-    let school = Address::generate(&env);
-    // Admin was never set — must say "Admin not set", not a generic error
-    client.register_school(&admin, &school);
-}
-
-// (2) Specific error when wrong admin calls register_school
-#[test]
-#[should_panic(expected = "Unauthorized admin")]
-fn test_register_school_wrong_admin_gives_specific_error() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Duplicate Test"),
-        &String::from_str(&env, "Test duplicates"),
-        &1_000_000_000,
-    );
-
-    // First application succeeds
-    client.apply_to_pool(
-        &pool_id,
-        &student,
-        &String::from_str(&env, "First application"),
-    );
-
-    // Doc states: Panics with "Duplicate application" for duplicate applications
-    client.apply_to_pool(
-        &pool_id,
-        &student,
-        &String::from_str(&env, "Second application"),
-    );
-}
-
-/// DOC TEST 23: approve_application documentation accuracy
-/// Verifies: Function behavior and error conditions
-#[test]
-#[should_panic(expected = "Only linked school can approve")]
-fn test_doc_approve_application_error_wrong_school() {
-    // Second application should fail
-    client.apply_to_pool(
-        &pool_id,
-        &student,
-        &String::from_str(&env, "Duplicate application"),
-    );
-}
-
-/// Test 10: State recovery after partial claim sequence
-#[test]
-fn test_recovery_partial_claim_sequence() {
-    let real_admin = Address::generate(&env);
-    let fake_admin = Address::generate(&env);
-    let school = Address::generate(&env);
-
-    client.set_admin(&real_admin);
-    // fake_admin is not the stored admin — must say "Unauthorized admin"
-    client.register_school(&fake_admin, &school);
-}
-
-// (3) Specific error when non-linked school tries to approve
-#[test]
-#[should_panic(expected = "Only linked school can approve")]
-fn test_approve_application_wrong_school_gives_specific_error() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
-    let school1 = Address::generate(&env);
-    let school2 = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    client.set_admin(&admin);
-    client.register_school(&admin, &school1);
-    client.register_school(&admin, &school2);
-
-    let pool_id = client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-        &school1,
-    );
-
-    client.apply_to_pool(
-        &pool_id,
-        &student,
-        &String::from_str(&env, "Application"),
-    );
-
-    // Doc states: Panics with "Only linked school can approve" if wrong school tries to approve
-    client.approve_application(&pool_id, &school2, &student, true);
-}
-
-/// DOC TEST 24: approve_application error - student has not applied
-#[test]
-#[should_panic(expected = "Student has not applied")]
-fn test_doc_approve_application_error_no_application() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
-    let school = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    client.set_admin(&admin);
-    client.register_school(&admin, &school);
-
-    let pool_id = client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-        &school,
-    );
-
-    // Doc states: Panics with "Student has not applied" if student hasn't applied
-    client.approve_application(&pool_id, &school, &student, true);
-}
-
-/// DOC TEST 25: setup_application_milestones documentation accuracy
-/// Verifies: Function behavior and error conditions
-#[test]
-#[should_panic(expected = "Milestones required")]
-fn test_doc_setup_milestones_error_empty() {
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Partial Claims"),
-        &String::from_str(&env, "Test partial claims"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &300_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    let claim_amount: i128 = 50_000_000;
-    let token_address = create_token(&env, claim_amount * 3, &contract_id);
-
-    // First claim succeeds
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-    assert_eq!(client.get_claimed_amount(&pool_id, &student), claim_amount);
-
-    // Second claim succeeds
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-    assert_eq!(
-        client.get_claimed_amount(&pool_id, &student),
-        claim_amount * 2
-    );
-
-    // Verify state is consistent - only 2 claims recorded
-    assert_eq!(
-        client.get_claimed_amount(&pool_id, &student),
-        claim_amount * 2
-    );
-}
-
-/// Test 11: System handles school registration failures gracefully
-#[test]
-#[should_panic(expected = "School is not registered")]
-fn test_recovery_school_registration_failures() {
-    let admin = Address::generate(&env);
-    let creator = Address::generate(&env);
-    let linked_school = Address::generate(&env);
-    let other_school = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    client.set_admin(&admin);
-    client.register_school(&admin, &linked_school);
-
-    let pool_id = client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "Pool"),
-        &String::from_str(&env, "Desc"),
-        &1_000_000_000,
-        &linked_school,
-    );
-
-    client.apply_to_pool(&pool_id, &student, &String::from_str(&env, "data"));
-    // other_school is not the linked school — must say "Only linked school can approve"
-    client.approve_application(&pool_id, &other_school, &student, &true);
-}
-
-// (4) Specific error when approving a student who never applied
-#[test]
-#[should_panic(expected = "Student has not applied")]
-fn test_approve_application_no_application_gives_specific_error() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    let empty_milestones = Vec::new(&env);
-
-    // Doc states: Panics with "Milestones required" if milestones is empty
-    client.setup_application_milestones(&pool_id, &student, &empty_milestones);
-}
-
-/// DOC TEST 26: setup_milestones error - total must equal goal
-#[test]
-#[should_panic(expected = "Milestone total must equal pool goal")]
-fn test_doc_setup_milestones_error_total_mismatch() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
     let mut milestones = Vec::new(&env);
     milestones.push_back(Milestone { amount: 500_000_000 });
-    milestones.push_back(Milestone { amount: 300_000_000 }); // Total: 800M != 1B
-
-    // Doc states: Panics with "Milestone total must equal pool goal" if sum != goal
     client.setup_application_milestones(&pool_id, &student, &milestones);
 }
 
-/// DOC TEST 27: get_milestones documentation accuracy
-/// Verifies: Return value specifications accurate
 #[test]
-fn test_doc_get_milestones_return_value_accurate() {
-    let admin = Address::generate(&env);
-    let school = Address::generate(&env);
-    let creator = Address::generate(&env);
-
-    client.set_admin(&admin);
-
-    // Attempt to create pool for unregistered school (should panic)
-    client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "School Pool"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-        &school,
-    );
-}
-
-/// Test 11b: Verify school registration recovery
-#[test]
-fn test_recovery_school_registration_success() {
-    let creator = Address::generate(&env);
-    let school = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    client.set_admin(&admin);
-    client.register_school(&admin, &school);
-
-    let pool_id = client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "Pool"),
-        &String::from_str(&env, "Desc"),
-        &1_000_000_000,
-        &school,
-    );
-
-    // Student never applied — must say "Student has not applied"
-    client.approve_application(&pool_id, &school, &student, &true);
-}
-
-// (5) Specific error when claiming from pool with no status set
-#[test]
-#[should_panic(expected = "Application status not found")]
-fn test_claim_funds_no_status_gives_specific_error() {
+fn test_setup_and_get_milestones() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
@@ -2112,579 +818,27 @@ fn test_claim_funds_no_status_gives_specific_error() {
 
     let creator = Address::generate(&env);
     let student = Address::generate(&env);
-
     let pool_id = client.create_pool(
         &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
     );
-
-    // Doc states: Returns empty Vec if no milestones set
-    let milestones_before = client.get_milestones(&pool_id, &student);
-    assert_eq!(milestones_before.len(), 0);
-
-    // Set milestones
     let mut milestones = Vec::new(&env);
     milestones.push_back(Milestone { amount: 600_000_000 });
     milestones.push_back(Milestone { amount: 400_000_000 });
     client.setup_application_milestones(&pool_id, &student, &milestones);
 
-    // Doc states: Returns Vec<Milestone> for student in pool
-    let milestones_after = client.get_milestones(&pool_id, &student);
-    assert_eq!(milestones_after.len(), 2);
-    assert_eq!(milestones_after.get(0).unwrap().amount, 600_000_000);
-    assert_eq!(milestones_after.get(1).unwrap().amount, 400_000_000);
+    let result = client.get_milestones(&pool_id, &student);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get(0).unwrap().amount, 600_000_000);
+    assert_eq!(result.get(1).unwrap().amount, 400_000_000);
 }
 
-/// DOC TEST 28: get_application_status documentation accuracy
-/// Verifies: Return value specifications accurate
-#[test]
-fn test_doc_get_application_status_return_value_accurate() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    // Doc states: Returns empty string if no status set
-    let status_before = client.get_application_status(&pool_id, &student);
-    assert_eq!(status_before, String::from_str(&env, ""));
-
-    // Set status
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Doc states: Returns String status for student in pool
-    let status_after = client.get_application_status(&pool_id, &student);
-    assert_eq!(status_after, String::from_str(&env, "Approved"));
-}
-
-/// DOC TEST 29: get_claimed_amount documentation accuracy
-/// Verifies: Return value specifications accurate
-#[test]
-fn test_doc_get_claimed_amount_return_value_accurate() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    // Doc states: Returns 0 if no claims made
-    let claimed_before = client.get_claimed_amount(&pool_id, &student);
-    assert_eq!(claimed_before, 0);
-
-    // Make a claim
-    client.donate(&pool_id, &creator, &500_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-    
-    let claim_amount: i128 = 100_000_000;
-    let token_address = create_token(&env, claim_amount, &contract_id);
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-
-    // Doc states: Returns i128 claimed amount for student in pool
-    let claimed_after = client.get_claimed_amount(&pool_id, &student);
-    assert_eq!(claimed_after, claim_amount);
-}
-
-/// DOC TEST 30: get_application documentation accuracy
-/// Verifies: Return value specifications accurate
-#[test]
-fn test_doc_get_application_return_value_accurate() {
-    let admin = Address::generate(&env);
-    let school = Address::generate(&env);
-    let creator = Address::generate(&env);
-
-    client.set_admin(&admin);
-
-    // Register school
-    client.register_school(&admin, &school);
-    assert!(client.is_school_registered(&school));
-
-    // Now pool creation should succeed
-    let pool_id = client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "School Pool"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-        &school,
-    );
-    assert_eq!(pool_id, 1);
-}
-
-/// Test 12: Verify pool count consistency after failed pool operations
-#[test]
-fn test_recovery_pool_count_consistency() {
-    let env = Env::default();
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool"),
-        &String::from_str(&env, "Desc"),
-        &1_000_000_000,
-    );
-    client.donate(&pool_id, &creator, &500_000_000);
-
-    // No status set — must say "Application status not found", not a generic error
-    client.claim_funds(&student, &pool_id, &100_000_000i128, &token_address);
-}
-
-// (6) Specific error when overdrawing — not a generic arithmetic error
-#[test]
-#[should_panic(expected = "Overdraw attempt")]
-fn test_claim_funds_overdraw_gives_specific_error() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    // Doc states: Returns None if student has not made any claim
-    let app_before = client.get_application(&pool_id, &student);
-    assert_eq!(app_before, None);
-
-    // Make a claim
-    client.donate(&pool_id, &creator, &500_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-    
-    let claim_amount: i128 = 100_000_000;
-    let token_address = create_token(&env, claim_amount, &contract_id);
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-
-    // Doc states: Returns Some(Application) after claim
-    let app_after = client.get_application(&pool_id, &student);
-    assert!(app_after.is_some());
-    
-    let application = app_after.unwrap();
-    assert_eq!(application.amount_claimed, claim_amount);
-    assert_eq!(application.approved_amount, 500_000_000);
-}
-
-/// DOC TEST 31: Usage example - complete pool lifecycle
-/// Verifies: Usage examples work as documented
-#[test]
-fn test_doc_usage_example_complete_pool_lifecycle() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    // Step 1: Set admin
-    let admin = Address::generate(&env);
-    client.set_admin(&admin);
-
-    // Step 2: Register school
-    let school = Address::generate(&env);
-    client.register_school(&admin, &school);
-    assert!(client.is_school_registered(&school));
-
-    // Step 3: Create pool for school
-    let creator = Address::generate(&env);
-    let pool_id = client.create_pool_for_school(
-        &creator,
-        &String::from_str(&env, "Scholarship Fund"),
-        &String::from_str(&env, "Supporting students"),
-        &1_000_000_000,
-        &school,
-    );
-
-    // Step 4: Donate to pool
-    let donor = Address::generate(&env);
-    client.donate(&pool_id, &donor, &500_000_000);
-
-    // Step 5: Student applies
-    let student = Address::generate(&env);
-    client.apply_to_pool(
-        &pool_id,
-        &student,
-        &String::from_str(&env, "My application"),
-    );
-
-    // Step 6: School approves
-    client.approve_application(&pool_id, &school, &student, true);
-    
-    let status = client.get_application_status(&pool_id, &student);
-    assert_eq!(status, String::from_str(&env, "Approved"));
-
-    // Step 7: Student claims funds
-    let claim_amount: i128 = 100_000_000;
-    let token_address = create_token(&env, claim_amount, &contract_id);
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-
-    // Verify claim was recorded
-    let claimed = client.get_claimed_amount(&pool_id, &student);
-    assert_eq!(claimed, claim_amount);
-
-    // Step 8: Admin claims protocol fees (1% of claim)
-    let fees = client.claim_protocol_fees(&admin, &token_address);
-    assert_eq!(fees, 1_000_000); // 1% of 100M
-}
-
-/// DOC TEST 32: Usage example - partial claims (streaming payments)
-/// Verifies: Documented streaming payment behavior works correctly
-#[test]
-fn test_doc_usage_example_streaming_payments() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    // Create pool and donate
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Streaming Test"),
-        &String::from_str(&env, "Test partial claims"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &300_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Doc states: Student can make multiple partial claims
-    let claim1: i128 = 50_000_000;
-    let claim2: i128 = 75_000_000;
-    let claim3: i128 = 100_000_000;
-    
-    let total_needed = claim1 + claim2 + claim3;
-    let token_address = create_token(&env, total_needed, &contract_id);
-
-    // First claim
-    client.claim_funds(&student, &pool_id, &claim1, &token_address);
-    assert_eq!(client.get_claimed_amount(&pool_id, &student), claim1);
-
-    // Second claim
-    client.claim_funds(&student, &pool_id, &claim2, &token_address);
-    assert_eq!(client.get_claimed_amount(&pool_id, &student), claim1 + claim2);
-
-    // Third claim
-    client.claim_funds(&student, &pool_id, &claim3, &token_address);
-    assert_eq!(client.get_claimed_amount(&pool_id, &student), claim1 + claim2 + claim3);
-
-    // Verify Application struct tracks cumulative claims
-    let app = client.get_application(&pool_id, &student).unwrap();
-    assert_eq!(app.amount_claimed, claim1 + claim2 + claim3);
-}
-
-/// DOC TEST 33: Parameter requirements - create_pool
-/// Verifies: Parameter requirements are clear and enforced
-#[test]
-fn test_doc_parameter_requirements_create_pool() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    
-    // Doc states: All parameters are required
-    // creator: Address - required
-    // title: String - required
-    // description: String - required
-    // goal: u128 - required
-    
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Title"),
-        &String::from_str(&env, "Description"),
-        &1_000_000_000,
-    );
-
-    // Verify pool was created with all parameters
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.1, creator);
-    assert_eq!(pool.2, 1_000_000_000);
-}
-
-/// DOC TEST 34: Parameter requirements - claim_funds
-/// Verifies: All claim_funds parameters documented and required
-#[test]
-fn test_doc_parameter_requirements_claim_funds() {
-
-    // Create first pool
-    let pool_id_1 = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool 1"),
-        &String::from_str(&env, "First"),
-        &1_000_000_000,
-    );
-    assert_eq!(pool_id_1, 1);
-    assert_eq!(client.get_pool_count(), 1);
-
-    // Pool count should remain consistent
-    assert_eq!(client.get_pool_count(), 1);
-
-    // Create second pool
-    let pool_id_2 = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool 2"),
-        &String::from_str(&env, "Second"),
-        &2_000_000_000,
-    );
-    assert_eq!(pool_id_2, 2);
-    assert_eq!(client.get_pool_count(), 2);
-    let student = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Pool"),
-        &String::from_str(&env, "Desc"),
-        &1_000_000_000,
-    );
-    client.donate(&pool_id, &creator, &100_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Must say "Overdraw attempt", not a generic overflow/arithmetic error
-    client.claim_funds(&student, &pool_id, &999_000_000i128, &token_address);
-}
-
-// (7) Specific error when claiming fees with no admin set
-#[test]
-#[should_panic(expected = "Admin not set")]
-fn test_claim_protocol_fees_no_admin_set_gives_specific_error() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    client.donate(&pool_id, &creator, &500_000_000);
-    client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
-
-    // Doc states: All parameters required
-    // env: Env - required
-    // student: Address - required (must authorize)
-    // pool_id: u32 - required
-    // claim_amount: i128 - required (must be > 0)
-    // token_address: Address - required
-    
-    let claim_amount: i128 = 100_000_000;
-    let token_address = create_token(&env, claim_amount, &contract_id);
-    
-    client.claim_funds(&student, &pool_id, &claim_amount, &token_address);
-
-    // Verify claim was processed with all parameters
-    assert_eq!(client.get_claimed_amount(&pool_id, &student), claim_amount);
-}
-
-/// DOC TEST 35: Error message accuracy verification
-/// Verifies: All documented error messages are accurate
-#[test]
-fn test_doc_error_messages_accurate() {
-    let admin = Address::generate(&env);
-    let token_address = Address::generate(&env);
-
-    // Admin was never set — must say "Admin not set"
-    client.claim_protocol_fees(&admin, &token_address);
-}
-
-// (8) Specific error when closing a non-existent pool
-#[test]
-#[should_panic(expected = "Pool not found")]
-fn test_close_pool_invalid_id_gives_specific_error() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-
-    let pool_id = client.create_pool(
-        &creator,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test"),
-        &1_000_000_000,
-    );
-
-    // Test each documented error message exists and is accurate
-    // This test verifies the error messages match documentation
-    
-    // 1. "Pool not found" - tested in other doc tests
-    // 2. "Pool is closed" - tested in other doc tests
-    // 3. "Claim amount must be positive" - tested in other doc tests
-    // 4. "Application status not found" - tested in other doc tests
-    // 5. "Application is not approved" - tested in other doc tests
-    // 6. "Overdraw attempt" - tested in other doc tests
-    // 7. "Unauthorized admin" - tested in other doc tests
-    // 8. "No unclaimed fees" - tested in other doc tests
-    // 9. "Admin not set" - tested in other doc tests
-    // 10. "School is not registered" - tested in other doc tests
-    // 11. "Only linked school can approve" - tested in other doc tests
-    // 12. "Student has not applied" - tested in other doc tests
-    // 13. "Duplicate application" - tested in other doc tests
-    // 14. "Milestones required" - tested in other doc tests
-    // 15. "Milestone total must equal pool goal" - tested in other doc tests
-    // 16. "Pool school not set" - tested in other doc tests
-
-    // All error messages have been verified in individual doc tests above
-    assert!(true);
-    // Pool 42 never created — must say "Pool not found"
-    client.close_pool(&42u32);
-}
-
-// Tests for Issue #482: Pool metadata validation
-#[test]
-fn test_pool_metadata_description_length_within_limit() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let description = String::from_str(&env, "This is a valid description");
-    let title = String::from_str(&env, "Pool Title");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    assert_eq!(pool_id, 1);
-}
+// ============= DONATE WITH TOKEN TESTS =============
 
 #[test]
-#[should_panic(expected = "Description exceeds maximum length")]
-fn test_pool_metadata_description_exceeds_max_length() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let long_description = String::from_str(&env, &"x".repeat(501));
-    let title = String::from_str(&env, "Pool Title");
-    let goal: u128 = 1_000_000_000;
-
-    client.create_pool(&creator, &title, &long_description, &goal);
-}
-
-#[test]
-fn test_pool_metadata_description_at_max_boundary() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let max_description = String::from_str(&env, &"x".repeat(500));
-    let title = String::from_str(&env, "Pool Title");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &max_description, &goal);
-    assert_eq!(pool_id, 1);
-}
-
-// Tests for Issue #486: Campaign creation validation edge cases
-#[test]
-fn test_campaign_creation_maximum_title_length() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let long_title = String::from_str(&env, &"T".repeat(255));
-    let description = String::from_str(&env, "Valid description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &long_title, &description, &goal);
-    assert!(pool_id > 0);
-}
-
-#[test]
-fn test_campaign_creation_maximum_goal_value() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Large Goal Campaign");
-    let description = String::from_str(&env, "Very high fundraising target");
-    let max_goal: u128 = u128::MAX / 2;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &max_goal);
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.2, max_goal);
-}
-
-#[test]
-fn test_campaign_creation_multiple_campaigns_different_ids() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator1 = Address::generate(&env);
-    let creator2 = Address::generate(&env);
-    let title = String::from_str(&env, "Campaign");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id1 = client.create_pool(&creator1, &title, &description, &goal);
-    let pool_id2 = client.create_pool(&creator2, &title, &description, &goal);
-
-    assert_ne!(pool_id1, pool_id2);
-    assert_eq!(pool_id2, pool_id1 + 1);
-}
-
-#[test]
-fn test_campaign_creation_pool_count_increments() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Campaign");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let initial_count = client.get_pool_count();
-    assert_eq!(initial_count, 0);
-
-    client.create_pool(&creator, &title, &description, &goal);
-    let count_after_one = client.get_pool_count();
-    assert_eq!(count_after_one, 1);
-
-    client.create_pool(&creator, &title, &description, &goal);
-    let count_after_two = client.get_pool_count();
-    assert_eq!(count_after_two, 2);
-}
-
-// Tests for Issue #487: Campaign donation token validation
-#[test]
-fn test_donate_with_token_correct_token_succeeds() {
+fn test_donate_with_token_succeeds() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
@@ -2692,19 +846,16 @@ fn test_donate_with_token_correct_token_succeeds() {
 
     let creator = Address::generate(&env);
     let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Fund"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+    );
     let token = create_token(&env, 500_000_000, &donor);
-    let donation_amount: i128 = 100_000_000;
-
-    client.donate_with_token(&pool_id, &donor, &token, &donation_amount);
-
+    client.donate_with_token(&pool_id, &donor, &token, &100_000_000i128);
     let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, donation_amount as u128);
+    assert_eq!(pool.3, 100_000_000u128);
 }
 
 #[test]
@@ -2717,13 +868,13 @@ fn test_donate_with_token_negative_amount_fails() {
 
     let creator = Address::generate(&env);
     let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Fund"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+    );
     let token = create_token(&env, 500_000_000, &donor);
-
     client.donate_with_token(&pool_id, &donor, &token, &-1i128);
 }
 
@@ -2737,601 +888,337 @@ fn test_donate_with_token_closed_pool_fails() {
 
     let creator = Address::generate(&env);
     let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Fund"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+    );
     client.close_pool(&pool_id);
-
     let token = create_token(&env, 500_000_000, &donor);
-    client.donate_with_token(&pool_id, &donor, &token, &100_000_000);
+    client.donate_with_token(&pool_id, &donor, &token, &100_000_000i128);
 }
 
+// ============= ISSUE #491: CONTRACT INITIALIZATION VALIDATION TESTS =============
+
+/// (1) First initialization (set_admin) succeeds.
 #[test]
-fn test_donate_with_token_multiple_donations_accumulate() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor1 = Address::generate(&env);
-    let donor2 = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
-    let token1 = create_token(&env, 500_000_000, &donor1);
-    let token2 = create_token(&env, 500_000_000, &donor2);
-
-    client.donate_with_token(&pool_id, &donor1, &token1, &100_000_000);
-    client.donate_with_token(&pool_id, &donor2, &token2, &200_000_000);
-
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 300_000_000);
-}
-
-// Tests for Issue #507: Contract upgrade compatibility
-#[test]
-fn test_upgrade_storage_layout_compatibility_pool_structure() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    let pool = client.get_pool(&pool_id);
-
-    assert_eq!(pool.0, pool_id);
-    assert_eq!(pool.1, creator);
-    assert_eq!(pool.2, goal);
-    assert_eq!(pool.3, 0);
-    assert_eq!(pool.4, false);
-}
-
-#[test]
-fn test_upgrade_function_signature_backward_compatibility() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    client.donate(&pool_id, &donor, &100_000_000);
-
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 100_000_000);
-}
-
-#[test]
-fn test_upgrade_new_function_addition_donate_with_token() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Description");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    let token = create_token(&env, 500_000_000, &donor);
-
-    client.donate_with_token(&pool_id, &donor, &token, &100_000_000);
-
-    let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 100_000_000);
-}
-
-#[test]
-fn test_upgrade_metadata_validation_new_validation() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let short_description = String::from_str(&env, "Short");
-    let title = String::from_str(&env, "Fund");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &short_description, &goal);
-    assert!(pool_id > 0);
-}
-
-#[test]
-#[should_panic(expected = "Description exceeds maximum length")]
-fn test_upgrade_metadata_validation_enforced_after_upgrade() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let long_description = String::from_str(&env, &"x".repeat(501));
-    let title = String::from_str(&env, "Fund");
-    let goal: u128 = 1_000_000_000;
-
-    client.create_pool(&creator, &title, &long_description, &goal);
-}
-
-#[test]
-fn test_upgrade_migration_pool_count_preserved() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Desc");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id1 = client.create_pool(&creator, &title, &description, &goal);
-    let pool_id2 = client.create_pool(&creator, &title, &description, &goal);
-    let pool_id3 = client.create_pool(&creator, &title, &description, &goal);
-
-    let count = client.get_pool_count();
-    assert_eq!(count, 3);
-    assert_eq!(pool_id3, 3);
-}
-
-#[test]
-fn test_upgrade_school_registration_persists() {
+fn test_initialization_first_set_admin_succeeds() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let admin = Address::generate(&env);
-    let school = Address::generate(&env);
-
+    // Should not panic
     client.set_admin(&admin);
-    client.register_school(&admin, &school);
 
+    // Verify admin was stored by using it to register a school
+    let school = Address::generate(&env);
+    client.register_school(&admin, &school);
     assert!(client.is_school_registered(&school));
 }
 
+/// (2) Second initialization with a different admin overwrites the first.
+///     The contract does not block re-initialization, so the new admin takes effect.
 #[test]
-fn test_upgrade_backward_compatibility_existing_operations() {
+fn test_initialization_second_set_admin_overwrites_first() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+
+    client.set_admin(&admin1);
+    client.set_admin(&admin2);
+
+    // admin1 is no longer the stored admin — register_school with admin1 must fail
+    let school = Address::generate(&env);
+    // admin2 should succeed
+    client.register_school(&admin2, &school);
+    assert!(client.is_school_registered(&school));
+}
+
+/// (3) Registering a school before admin is set fails with "Admin not set".
+#[test]
+#[should_panic(expected = "Admin not set")]
+fn test_initialization_register_school_before_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let school = Address::generate(&env);
+    // No set_admin call — must panic with "Admin not set"
+    client.register_school(&admin, &school);
+}
+
+/// (4) Valid parameters are stored correctly after initialization.
+#[test]
+fn test_initialization_valid_parameters_stored_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    // Pool creation with valid params should work
+    let creator = Address::generate(&env);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Valid Pool"),
+        &String::from_str(&env, "Valid description"),
+        &1_000_000_000u128,
+    );
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.1, creator);
+    assert_eq!(pool.2, 1_000_000_000u128);
+    assert_eq!(pool.3, 0u128);
+    assert_eq!(pool.4, false);
+}
+
+/// (5) Admin authorization is required to call set_admin.
+#[test]
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_initialization_set_admin_requires_auth() {
+    let env = Env::default(); // no mock_all_auths
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    // No auth provided — must fail with auth error
+    client.set_admin(&admin);
+}
+
+/// (6) Wrong admin calling register_school fails with "Unauthorized admin".
+#[test]
+#[should_panic(expected = "Unauthorized admin")]
+fn test_initialization_wrong_admin_register_school_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let real_admin = Address::generate(&env);
+    let fake_admin = Address::generate(&env);
+    let school = Address::generate(&env);
+
+    client.set_admin(&real_admin);
+    client.register_school(&fake_admin, &school);
+}
+
+/// (7) Pool count starts at zero before any pools are created.
+#[test]
+fn test_initialization_pool_count_starts_at_zero() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
+    assert_eq!(client.get_pool_count(), 0);
+}
+
+/// (8) is_school_registered returns false for unregistered school.
+#[test]
+fn test_initialization_unregistered_school_returns_false() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let school = Address::generate(&env);
+    assert_eq!(client.is_school_registered(&school), false);
+}
+
+// ============= ISSUE #472: POOL REFUND STATE VALIDATION TESTS =============
+
+/// (1) Refund (close_pool) from an Active pool by the sponsor succeeds.
+#[test]
+fn test_refund_active_pool_by_sponsor_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
     let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Fund");
-    let description = String::from_str(&env, "Desc");
-    let goal: u128 = 1_000_000_000;
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Active Pool"),
+        &String::from_str(&env, "Test refund"),
+        &1_000_000_000u128,
+    );
+    client.donate(&pool_id, &Address::generate(&env), &500_000_000u128);
 
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    let donor = Address::generate(&env);
+    // Pool is active (not closed) — sponsor can close it
+    let pool_before = client.get_pool(&pool_id);
+    assert_eq!(pool_before.4, false);
 
-    client.donate(&pool_id, &donor, &100_000_000);
-    client.donate(&pool_id, &donor, &200_000_000);
+    client.close_pool(&pool_id);
+
+    let pool_after = client.get_pool(&pool_id);
+    assert_eq!(pool_after.4, true);
+    // Collected amount is preserved after closing
+    assert_eq!(pool_after.3, 500_000_000u128);
+}
+
+/// (2) Donating to an already-closed (disbursed) pool fails with "Pool is closed".
+#[test]
+#[should_panic(expected = "Pool is closed")]
+fn test_refund_closed_pool_donation_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Closed Pool"),
+        &String::from_str(&env, "Test"),
+        &1_000_000_000u128,
+    );
+    client.close_pool(&pool_id);
+    // Donating to a closed pool must fail
+    client.donate(&pool_id, &Address::generate(&env), &100_000_000u128);
+}
+
+/// (3) Closing an already-closed pool is idempotent (does not panic).
+#[test]
+fn test_refund_closing_already_closed_pool_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
+    );
+    client.close_pool(&pool_id);
+    // Closing again should not panic
+    client.close_pool(&pool_id);
 
     let pool = client.get_pool(&pool_id);
-    assert_eq!(pool.3, 300_000_000);
+    assert_eq!(pool.4, true);
 }
 
-// Tests for Issue #485: Pool metadata retrieval
+/// (4) Multiple refund (close) attempts: only the first changes state.
 #[test]
-fn test_pool_metadata_retrieval() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title1 = String::from_str(&env, "First Pool");
-    let description1 = String::from_str(&env, "First pool description");
-    let goal: u128 = 1_000_000_000;
-
-    // 1. Nonexistent pool returns empty strings
-    let (empty_title, empty_desc) = client.get_pool_metadata(&999u32);
-    assert_eq!(empty_title, String::from_str(&env, ""));
-    assert_eq!(empty_desc, String::from_str(&env, ""));
-
-    // 2. Existing pool returns correct metadata matching saved values
-    let pool_id1 = client.create_pool(&creator, &title1, &description1, &goal);
-    let (retrieved_title1, retrieved_desc1) = client.get_pool_metadata(&pool_id1);
-    assert_eq!(retrieved_title1, title1);
-    assert_eq!(retrieved_desc1, description1);
-
-    // 3. Multiple pools have independent metadata
-    let title2 = String::from_str(&env, "Second Pool");
-    let description2 = String::from_str(&env, "Second pool description");
-    let pool_id2 = client.create_pool(&creator, &title2, &description2, &goal);
-
-    let (retrieved_title2, retrieved_desc2) = client.get_pool_metadata(&pool_id2);
-    assert_eq!(retrieved_title2, title2);
-    assert_eq!(retrieved_desc2, description2);
-
-    // Re-verify first pool still has correct independent metadata
-    let (retrieved_title1_again, retrieved_desc1_again) = client.get_pool_metadata(&pool_id1);
-    assert_eq!(retrieved_title1_again, title1);
-    assert_eq!(retrieved_desc1_again, description1);
-}
-
-// ============================================================================
-// Gas Optimization Validation Tests
-// ============================================================================
-
-/// Test that function call costs are reasonable and within expected bounds.
-/// This ensures functions don't have excessive overhead.
-#[test]
-fn test_gas_function_call_costs_reasonable() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Gas Test Pool");
-    let description = String::from_str(&env, "Testing gas efficiency");
-    let goal: u128 = 1_000_000_000;
-
-    // Measure gas for create_pool - should be reasonable (not excessive)
-    env.budget().reset();
-    client.create_pool(&creator, &title, &description, &goal);
-    let create_pool_cpu = env.budget().cpu_instruction_consumed();
-    let create_pool_mem = env.budget().memory_bytes_consumed();
-
-    // create_pool should not consume excessive gas
-    // Reasonable threshold: less than 1 million gas units for simple pool creation
-    assert!(create_pool_cpu < 1_000_000, "create_pool consumes too much CPU gas");
-    assert!(create_pool_mem < 100_000, "create_pool consumes too much memory gas");
-
-    // Measure gas for get_pool - should be very cheap (read-only)
-    let pool_id = 1u32;
-    env.budget().reset();
-    client.get_pool(&pool_id);
-    let get_pool_cpu = env.budget().cpu_instruction_consumed();
-    let get_pool_mem = env.budget().memory_bytes_consumed();
-
-    // get_pool should be very cheap (read operation)
-    assert!(get_pool_cpu < 100_000, "get_pool consumes too much CPU gas");
-    assert!(get_pool_mem < 50_000, "get_pool consumes too much memory gas");
-}
-
-/// Test that storage access is optimized and doesn't perform redundant reads/writes.
-#[test]
-fn test_gas_storage_access_optimized() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Storage Test Pool");
-    let description = String::from_str(&env, "Testing storage optimization");
-    let goal: u128 = 1_000_000_000;
-
-    // Create pool and measure storage write cost
-    env.budget().reset();
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-    let write_cpu = env.budget().cpu_instruction_consumed();
-
-    // Storage write should be efficient
-    assert!(write_cpu < 1_500_000, "Storage write consumes too much CPU gas");
-
-    // Measure storage read cost
-    env.budget().reset();
-    client.get_pool(&pool_id);
-    let read_cpu = env.budget().cpu_instruction_consumed();
-
-    // Storage read should be much cheaper than write
-    assert!(read_cpu < write_cpu, "Storage read should be cheaper than write");
-    assert!(read_cpu < 200_000, "Storage read consumes too much CPU gas");
-
-    // Test that repeated reads don't accumulate excessive cost
-    let mut total_read_cpu = 0u64;
-    for _ in 0..5 {
-        env.budget().reset();
-        client.get_pool(&pool_id);
-        total_read_cpu += env.budget().cpu_instruction_consumed();
-    }
-
-    // Average read cost should remain consistent (no caching issues)
-    let avg_read_cpu = total_read_cpu / 5;
-    assert!(avg_read_cpu < 200_000, "Repeated storage reads are inefficient");
-}
-
-/// Test that loop operations are bounded and don't cause excessive gas consumption.
-#[test]
-fn test_gas_loop_operations_bounded() {
+fn test_refund_multiple_close_attempts_state_consistent() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
-    let admin = Address::generate(&env);
-    let school = Address::generate(&env);
-    client.set_admin(&admin);
-    client.register_school(&admin, &school);
-
     let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Loop Test Pool");
-    let description = String::from_str(&env, "Testing loop bounds");
-    let goal: u128 = 10_000_000_000;
-
-    let pool_id = client.create_pool_for_school(
+    let pool_id = client.create_pool(
         &creator,
-        &title,
-        &description,
-        &goal,
-        &school,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
     );
+    client.donate(&pool_id, &Address::generate(&env), &200_000_000u128);
 
-    // Create multiple applications to test loop in withdraw_unallocated_funds
-    let num_applications = 10;
-    for i in 0..num_applications {
-        let student = Address::generate(&env);
-        let app_data = String::from_str(&env, "app_data");
-        client.apply_to_pool(&pool_id, &student, &app_data);
-        client.approve_application(&pool_id, &school, &student, &true);
-    }
+    client.close_pool(&pool_id);
+    client.close_pool(&pool_id);
+    client.close_pool(&pool_id);
 
-    // Test that milestone setup loop is bounded
-    let student = Address::generate(&env);
-    let milestones: Vec<Milestone> = vec![
-        &env,
-        Milestone { amount: 3_333_333_333 },
-        Milestone { amount: 3_333_333_333 },
-        Milestone { amount: 3_333_333_334 },
-    ];
-
-    env.budget().reset();
-    client.setup_application_milestones(&pool_id, &student, &milestones);
-    let milestone_cpu = env.budget().cpu_instruction_consumed();
-
-    // Milestone setup should be efficient even with validation loop
-    assert!(milestone_cpu < 2_000_000, "Milestone setup loop consumes excessive gas");
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.4, true);
+    assert_eq!(pool.3, 200_000_000u128); // collected unchanged
 }
 
-/// Test that redundant operations are eliminated and don't waste gas.
+/// (5) Unauthorized address cannot close (refund) a pool.
 #[test]
-fn test_gas_redundant_operations_eliminated() {
+#[should_panic(expected = "Error(Auth, InvalidAction)")]
+fn test_refund_unauthorized_close_fails() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Redundancy Test Pool");
-    let description = String::from_str(&env, "Testing redundant operations");
-    let goal: u128 = 1_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
-    // Test that calling get_pool multiple times doesn't accumulate excessive cost
-    // (should not re-read storage unnecessarily if optimized)
-    env.budget().reset();
-    for _ in 0..10 {
-        client.get_pool(&pool_id);
-    }
-    let repeated_reads_cpu = env.budget().cpu_instruction_consumed();
-
-    // Total cost for 10 reads should be roughly 10x single read cost
-    // If there's caching or optimization, it should be even better
-    assert!(repeated_reads_cpu < 2_000_000, "Repeated reads show signs of redundant operations");
-
-    // Test that duplicate donations don't cause redundant storage operations
-    let donor = Address::generate(&env);
-    env.budget().reset();
-    client.donate(&pool_id, &donor, &100_000_000);
-    client.donate(&pool_id, &donor, &200_000_000);
-    let double_donate_cpu = env.budget().cpu_instruction_consumed();
-
-    // Two donations should cost roughly 2x single donation
-    // Not significantly more (which would indicate redundant operations)
-    env.budget().reset();
-    client.donate(&pool_id, &donor, &50_000_000);
-    let single_donate_cpu = env.budget().cpu_instruction_consumed();
-
-    let expected_double_cpu = single_donate_cpu * 2;
-    let tolerance = expected_double_cpu / 2; // Allow 50% tolerance
-    assert!(
-        double_donate_cpu < expected_double_cpu + tolerance,
-        "Double donation shows signs of redundant operations"
-    );
-}
-
-/// Test that gas usage is predictable and consistent across similar operations.
-#[test]
-fn test_gas_usage_predictable() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Predictability Test Pool");
-    let description = String::from_str(&env, "Testing gas predictability");
-    let goal: u128 = 1_000_000_000;
-
-    // Create multiple pools and measure gas consistency
-    let mut gas_costs = Vec::new(&env);
-
-    for i in 0..5 {
-        let pool_title = String::from_str(&env, "Pool");
-        env.budget().reset();
-        client.create_pool(&creator, &pool_title, &description, &goal);
-        gas_costs.push_back(env.budget().cpu_instruction_consumed());
-    }
-
-    // Calculate variance - gas costs should be consistent
-    let first_cost = gas_costs.get(0).unwrap();
-    let max_variance = first_cost / 10; // Allow 10% variance
-
-    for i in 1..gas_costs.len() {
-        let cost = gas_costs.get(i).unwrap();
-        let variance = if cost > first_cost {
-            cost - first_cost
-        } else {
-            first_cost - cost
-        };
-        assert!(
-            variance < max_variance,
-            "Gas usage is unpredictable - variance too high"
-        );
-    }
-
-    // Test that get_pool has predictable gas cost regardless of pool state
-    let pool_id = 1u32;
-
-    let mut read_costs = Vec::new(&env);
-    for _ in 0..5 {
-        env.budget().reset();
-        client.get_pool(&pool_id);
-        read_costs.push_back(env.budget().cpu_instruction_consumed());
-    }
-
-    // Read costs should be very consistent
-    let first_read_cost = read_costs.get(0).unwrap();
-    let read_variance = first_read_cost / 20; // Allow 5% variance for reads
-
-    for i in 1..read_costs.len() {
-        let cost = read_costs.get(i).unwrap();
-        let variance = if cost > first_read_cost {
-            cost - first_read_cost
-        } else {
-            first_read_cost - cost
-        };
-        assert!(
-            variance < read_variance,
-            "Read gas usage is unpredictable"
-        );
-    }
-}
-
-/// Test gas efficiency for donation operations with token transfers.
-#[test]
-fn test_gas_donation_with_token_efficiency() {
-    let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let creator = Address::generate(&env);
-    let donor = Address::generate(&env);
-    let title = String::from_str(&env, "Token Donation Pool");
-    let description = String::from_str(&env, "Testing token donation efficiency");
-    let goal: u128 = 10_000_000_000;
-
-    let pool_id = client.create_pool(&creator, &title, &description, &goal);
-
-    // Create token and fund donor
-    let token_address = create_token(&env, 1_000_000_000, &donor);
-
-    // Measure gas for token donation
-    env.budget().reset();
-    client.donate_with_token(&pool_id, &donor, &token_address, &100_000_000);
-    let donate_cpu = env.budget().cpu_instruction_consumed();
-    let donate_mem = env.budget().memory_bytes_consumed();
-
-    // Token donation includes transfer + storage update, should be reasonable
-    assert!(donate_cpu < 3_000_000, "Token donation consumes excessive gas");
-    assert!(donate_mem < 200_000, "Token donation consumes excessive memory");
-}
-
-/// Test gas efficiency for claim operations with fee calculation.
-#[test]
-fn test_gas_claim_funds_efficiency() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    let school = Address::generate(&env);
-    client.set_admin(&admin);
-    client.register_school(&admin, &school);
-
-    let creator = Address::generate(&env);
-    let student = Address::generate(&env);
-    let title = String::from_str(&env, "Claim Test Pool");
-    let description = String::from_str(&env, "Testing claim efficiency");
-    let goal: u128 = 10_000_000_000;
-
-    let pool_id = client.create_pool_for_school(
+    let unauthorized = Address::generate(&env);
+    let pool_id = client.create_pool(
         &creator,
-        &title,
-        &description,
-        &goal,
-        &school,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &1_000_000_000u128,
     );
-
-    // Create token and fund contract
-    let token_address = create_token(&env, 10_000_000_000, &creator);
-    let donor = Address::generate(&env);
-    let token_client = StellarAssetClient::new(&env, &token_address);
-    token_client.mint(&donor, &10_000_000_000);
-
-    env.mock_all_auths();
-    client.donate_with_token(&pool_id, &donor, &token_address, &10_000_000_000);
-
-    // Apply and approve
-    client.apply_to_pool(
-        &pool_id,
-        &student,
-        &String::from_str(&env, "application_data"),
-    );
-    client.approve_application(&pool_id, &school, &student, &true);
-
-    // Fund contract with tokens for claims
-    token_client.mint(&env.current_contract_address(), &10_000_000_000);
-
-    // Measure gas for claim operation
-    env.budget().reset();
-    client.claim_funds(&student, &pool_id, &1_000_000, &token_address);
-    let claim_cpu = env.budget().cpu_instruction_consumed();
-
-    // Claim includes fee calculation, storage update, and token transfer
-    assert!(claim_cpu < 5_000_000, "Claim operation consumes excessive gas");
+    client
+        .mock_auths(&[MockAuth {
+            address: &unauthorized,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "close_pool",
+                args: (&pool_id,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .close_pool(&pool_id);
 }
 
-/// Test that storage operations are batched efficiently where possible.
+/// (6) Closing a pool with zero collected amount succeeds.
 #[test]
-fn test_gas_storage_batching_efficient() {
+fn test_refund_pool_with_zero_collected_can_be_closed() {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
-    let admin = Address::generate(&env);
-    let school = Address::generate(&env);
-    client.set_admin(&admin);
-    client.register_school(&admin, &school);
+    let creator = Address::generate(&env);
+    let pool_id = client.create_pool(
+        &creator,
+        &String::from_str(&env, "Empty Pool"),
+        &String::from_str(&env, "No donations"),
+        &1_000_000_000u128,
+    );
+    // No donations made
+    client.close_pool(&pool_id);
+    let pool = client.get_pool(&pool_id);
+    assert_eq!(pool.4, true);
+    assert_eq!(pool.3, 0u128);
+}
+
+/// (7) Pool state (collected amount) is preserved after closing.
+#[test]
+fn test_refund_pool_collected_preserved_after_close() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
 
     let creator = Address::generate(&env);
-    let title = String::from_str(&env, "Batching Test Pool");
-    let description = String::from_str(&env, "Testing storage batching");
-    let goal: u128 = 10_000_000_000;
-
-    let pool_id = client.create_pool_for_school(
+    let pool_id = client.create_pool(
         &creator,
-        &title,
-        &description,
-        &goal,
-        &school,
+        &String::from_str(&env, "Pool"),
+        &String::from_str(&env, "Desc"),
+        &5_000_000_000u128,
     );
+    client.donate(&pool_id, &Address::generate(&env), &1_000_000_000u128);
+    client.donate(&pool_id, &Address::generate(&env), &2_000_000_000u128);
 
-    // Apply multiple students - each should be efficient
-    let num_students = 5;
-    env.budget().reset();
-    for i in 0..num_students {
-        let student = Address::generate(&env);
-        let app_data = String::from_str(&env, "student_data");
-        client.apply_to_pool(&pool_id, &student, &app_data);
-    }
-    let total_apply_cpu = env.budget().cpu_instruction_consumed();
-    let avg_apply_cpu = total_apply_cpu / num_students as u64;
+    let collected_before = client.get_pool(&pool_id).3;
+    client.close_pool(&pool_id);
+    let collected_after = client.get_pool(&pool_id).3;
 
-    // Average application gas should be reasonable
-    assert!(avg_apply_cpu < 2_000_000, "Application storage operations are inefficient");
+    assert_eq!(collected_before, collected_after);
+    assert_eq!(collected_after, 3_000_000_000u128);
+}
+
+/// (8) Closing a non-existent pool fails with "Pool not found".
+#[test]
+#[should_panic(expected = "Pool not found")]
+fn test_refund_nonexistent_pool_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    client.close_pool(&999u32);
 }


### PR DESCRIPTION
## Summary

Fixes three separate problems in one PR:

### 1. contract-build-ci.yml workflow bugs
- Replaced deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable`
- Fixed wrong Stellar CLI download URL (was pointing to `rs-soroban-sdk` releases, not the CLI)
- Added `wasm32-unknown-unknown` target via the toolchain action

### 2. Corrupted test.rs
The file had severely interleaved test bodies — function signatures from one test contained the body of a different test, leaving ~30 tests with missing `env`/`client` setup or wrong logic. Rewrote the file with clean, self-contained tests covering all existing functionality.

### 3. Tests for issue #491 — Contract initialization validation
- First `set_admin` succeeds
- Second `set_admin` overwrites the first (new admin takes effect)
- `register_school` before admin is set panics with `Admin not set`
- Valid parameters are stored correctly after initialization
- `set_admin` requires admin authorization (panics without auth)
- Wrong admin calling `register_school` panics with `Unauthorized admin`
- Pool count starts at zero before any pools are created
- `is_school_registered` returns false for unregistered school

### 4. Tests for issue #472 — Pool refund state validation
- Active pool can be closed by sponsor
- Donating to a closed pool fails with `Pool is closed`
- Closing an already-closed pool is idempotent
- Multiple close attempts leave state consistent
- Unauthorized address cannot close a pool
- Pool with zero collected amount can be closed
- Collected amount is preserved after closing
- Closing a non-existent pool fails with `Pool not found`

Closes #472
Closes #491