### PR TITLE
Add client-side API rate limiting and request throttling

### DIFF
--- a/nevo_frontend/__tests__/api-client.test.ts
+++ b/nevo_frontend/__tests__/api-client.test.ts
@@ -1,0 +1,143 @@
+import { ApiClient, RateLimitError } from '@/lib/api-client';
+
+function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  const status = init.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: init.statusText ?? '',
+    headers: new Headers(
+      init.headers ?? { 'Content-Type': 'application/json' }
+    ),
+    json: jest.fn().mockResolvedValue(data),
+    text: jest.fn().mockResolvedValue(JSON.stringify(data)),
+  } as unknown as Response;
+}
+
+class TestHeaders {
+  private values = new Map<string, string>();
+
+  constructor(init?: HeadersInit) {
+    if (!init) return;
+
+    if (init instanceof TestHeaders) {
+      init.values.forEach((value, key) => this.values.set(key, value));
+      return;
+    }
+
+    if (Array.isArray(init)) {
+      init.forEach(([key, value]) => this.set(key, value));
+      return;
+    }
+
+    Object.entries(init as Record<string, string>).forEach(([key, value]) =>
+      this.set(key, value)
+    );
+  }
+
+  get(name: string) {
+    return this.values.get(name.toLowerCase()) ?? null;
+  }
+
+  has(name: string) {
+    return this.values.has(name.toLowerCase());
+  }
+
+  set(name: string, value: string) {
+    this.values.set(name.toLowerCase(), value);
+  }
+}
+
+describe('ApiClient rate limiting', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'Headers', {
+      value: TestHeaders,
+      configurable: true,
+    });
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    global.fetch = jest.fn();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('blocks requests once the client-side window is exhausted', async () => {
+    const client = new ApiClient('https://api.test', 1000, {
+      maxRequests: 1,
+      windowMs: 60_000,
+    });
+    (global.fetch as jest.Mock).mockResolvedValue(jsonResponse({ ok: true }));
+
+    await client.post('/pools', { title: 'One' }, { requireAuth: false });
+
+    await expect(
+      client.post('/pools', { title: 'Two' }, { requireAuth: false })
+    ).rejects.toBeInstanceOf(RateLimitError);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows requests again after the tracked window resets', async () => {
+    const client = new ApiClient('https://api.test', 1000, {
+      maxRequests: 1,
+      windowMs: 1_000,
+    });
+    (global.fetch as jest.Mock).mockResolvedValue(jsonResponse({ ok: true }));
+
+    await client.get('/pools', { requireAuth: false, cacheResponse: false });
+    await expect(
+      client.get('/pools', { requireAuth: false, cacheResponse: false })
+    ).rejects.toBeInstanceOf(RateLimitError);
+
+    jest.advanceTimersByTime(1_000);
+
+    await client.get('/pools', { requireAuth: false, cacheResponse: false });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves cached GET responses without spending another request', async () => {
+    const client = new ApiClient('https://api.test', 1000, {
+      maxRequests: 1,
+      windowMs: 60_000,
+    });
+    (global.fetch as jest.Mock).mockResolvedValue(
+      jsonResponse({ id: 'cached-pool' })
+    );
+
+    const first = await client.get('/pools/1', { requireAuth: false });
+    const second = await client.get('/pools/1', { requireAuth: false });
+
+    expect(first).toEqual({ id: 'cached-pool' });
+    expect(second).toEqual(first);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('converts server 429 responses into retry-aware rate limit errors', async () => {
+    const client = new ApiClient('https://api.test', 1000, {
+      maxRequests: 10,
+      windowMs: 60_000,
+    });
+    (global.fetch as jest.Mock).mockResolvedValue(
+      jsonResponse(
+        { error: 'Too many requests' },
+        {
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: { 'Retry-After': '5' },
+        }
+      )
+    );
+
+    await expect(
+      client.get('/limited', { requireAuth: false, cacheResponse: false })
+    ).rejects.toMatchObject({
+      name: 'RateLimitError',
+      retryAfterMs: 5_000,
+      status: 429,
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/nevo_frontend/__tests__/stellar.test.ts
+++ b/nevo_frontend/__tests__/stellar.test.ts
@@ -1,4 +1,5 @@
 import { getAccountBalances } from '@/lib/stellar';
+import { RATE_LIMIT_EVENT } from '@/lib/rate-limit';
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
@@ -33,5 +34,26 @@ describe('getAccountBalances', () => {
   it('returns zeros when balances array is missing', async () => {
     mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
     expect(await getAccountBalances('GABC')).toEqual({ xlm: '0', usdc: '0' });
+  });
+
+  it('notifies users when Horizon returns a rate limit response', async () => {
+    const listener = jest.fn();
+    window.addEventListener(RATE_LIMIT_EVENT, listener);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      headers: { get: () => '5' },
+    });
+
+    expect(await getAccountBalances('GABC')).toEqual({ xlm: '0', usdc: '0' });
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          retryAfterMs: 5000,
+        }),
+      })
+    );
+
+    window.removeEventListener(RATE_LIMIT_EVENT, listener);
   });
 });

--- a/nevo_frontend/app/layout.tsx
+++ b/nevo_frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import Navbar from '@/components/Navbar';
+import { RateLimitToast } from '@/components/RateLimitToast';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -72,7 +73,9 @@ export default function RootLayout({
       <head>
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationJsonLd),
+          }}
         />
         <script
           dangerouslySetInnerHTML={{
@@ -83,6 +86,7 @@ export default function RootLayout({
       <body className="min-h-full flex flex-col">
         <Navbar />
         {children}
+        <RateLimitToast />
       </body>
     </html>
   );

--- a/nevo_frontend/app/pools/[id]/page.tsx
+++ b/nevo_frontend/app/pools/[id]/page.tsx
@@ -197,7 +197,10 @@ export default function PoolDetailPage() {
           Pools
         </Link>
         <ChevronRightIcon />
-        <span className="font-medium text-[var(--color-text)]" aria-current="page">
+        <span
+          className="font-medium text-[var(--color-text)]"
+          aria-current="page"
+        >
           {pool.title}
         </span>
       </nav>
@@ -270,7 +273,10 @@ export default function PoolDetailPage() {
           )}
 
           <section aria-labelledby="contributors-heading">
-            <h2 id="contributors-heading" className="mb-4 text-lg font-semibold">
+            <h2
+              id="contributors-heading"
+              className="mb-4 text-lg font-semibold"
+            >
               Contributors
               <span className="ml-2 text-sm font-normal text-[var(--color-text-muted)]">
                 ({contributors.length})
@@ -278,41 +284,43 @@ export default function PoolDetailPage() {
             </h2>
 
             {contributors.length === 0 ? (
-              <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-8 text-center">
-                <p className="font-semibold">No contributions yet</p>
-                <p className="mt-1 text-sm text-[var(--color-text-muted)]">
-                  Be the first to support this pool.
-                </p>
-                {isActive && (
-                  <button
-                    type="button"
-                    onClick={() => setDonateOpen(true)}
-                    className="mt-4 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white hover:bg-brand-700 transition-colors"
-                  >
-                    Donate Now
-                  </button>
-                )}
-              </div>
-              <EmptyState
-                variant="compact"
-                icon="contributors"
-                iconTone="muted"
-                title="No contributions yet"
-                description="Be the first to support this pool."
-                action={
-                  isActive
-                    ? {
-                        label: 'Donate Now',
-                        onClick: () => setDonateOpen(true),
-                      }
-                    : undefined
-                }
-                steps={[
-                  { text: 'Connect your Stellar wallet' },
-                  { text: 'Choose an amount to donate' },
-                  { text: 'Confirm the transaction in Freighter' },
-                ]}
-              />
+              <>
+                <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-8 text-center">
+                  <p className="font-semibold">No contributions yet</p>
+                  <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+                    Be the first to support this pool.
+                  </p>
+                  {isActive && (
+                    <button
+                      type="button"
+                      onClick={() => setDonateOpen(true)}
+                      className="mt-4 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white hover:bg-brand-700 transition-colors"
+                    >
+                      Donate Now
+                    </button>
+                  )}
+                </div>
+                <EmptyState
+                  variant="compact"
+                  icon="contributors"
+                  iconTone="muted"
+                  title="No contributions yet"
+                  description="Be the first to support this pool."
+                  action={
+                    isActive
+                      ? {
+                          label: 'Donate Now',
+                          onClick: () => setDonateOpen(true),
+                        }
+                      : undefined
+                  }
+                  steps={[
+                    { text: 'Connect your Stellar wallet' },
+                    { text: 'Choose an amount to donate' },
+                    { text: 'Confirm the transaction in Freighter' },
+                  ]}
+                />
+              </>
             ) : (
               <ul className="flex flex-col gap-2" role="list">
                 {contributors.map((c, i) => (
@@ -346,16 +354,18 @@ export default function PoolDetailPage() {
             </h2>
 
             {timeline.length === 0 ? (
-              <p className="text-sm text-[var(--color-text-muted)]">
-                Pool milestones and donations will appear here as they happen.
-              </p>
-              <EmptyState
-                variant="compact"
-                icon="history"
-                iconTone="muted"
-                title="No activity yet"
-                description="Pool milestones and donations will appear here as they happen."
-              />
+              <>
+                <p className="text-sm text-[var(--color-text-muted)]">
+                  Pool milestones and donations will appear here as they happen.
+                </p>
+                <EmptyState
+                  variant="compact"
+                  icon="history"
+                  iconTone="muted"
+                  title="No activity yet"
+                  description="Pool milestones and donations will appear here as they happen."
+                />
+              </>
             ) : (
               <ol
                 className="relative border-l border-[var(--color-border)] pl-6"
@@ -388,7 +398,10 @@ export default function PoolDetailPage() {
           </section>
         </div>
 
-        <aside className="flex flex-col gap-6" aria-label="Pool funding details">
+        <aside
+          className="flex flex-col gap-6"
+          aria-label="Pool funding details"
+        >
           <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-6">
             <p className="text-3xl font-bold text-brand-600">
               {pool.raised.toLocaleString()}{' '}
@@ -545,7 +558,11 @@ function TagIcon() {
         strokeLinejoin="round"
         d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
       />
-      <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6Z" />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 6h.008v.008H6V6Z"
+      />
     </svg>
   );
 }

--- a/nevo_frontend/app/pools/page.tsx
+++ b/nevo_frontend/app/pools/page.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { EmptyState } from '@/components/EmptyState';
-import { usePoolsStore, type Pool } from '@/src/store/poolsStore';
 import {
   usePoolsStore,
   type Pool,
@@ -207,42 +206,44 @@ export default function BrowsePoolsPage() {
           )}
 
           {displayedPools.length === 0 ? (
-            <EmptyState
-              variant="bordered"
-              icon="search"
-              iconTone="muted"
-              title="No results found"
-              description="We couldn't find any pools matching your search criteria. Try adjusting your filters or search term."
-              action={{
-                label: 'Clear search',
-                onClick: () => {
-                  setSearchInput('');
-                  setSearch('');
-                },
-                variant: 'link',
-              }}
-              secondaryAction={{
-                label: 'Create a Pool',
-                href: '/pools/new',
-                variant: 'primary',
-              }}
-            />
-            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-[var(--color-border)] bg-[var(--color-surface-raised)] py-24 text-center">
-              <div className="flex size-12 items-center justify-center rounded-full bg-[var(--color-border)] text-[var(--color-text-muted)] mb-4">
-                <SearchIcon />
+            <>
+              <EmptyState
+                variant="bordered"
+                icon="search"
+                iconTone="muted"
+                title="No results found"
+                description="We couldn't find any pools matching your search criteria. Try adjusting your filters or search term."
+                action={{
+                  label: 'Clear search',
+                  onClick: () => {
+                    setSearchInput('');
+                    setSearch('');
+                  },
+                  variant: 'link',
+                }}
+                secondaryAction={{
+                  label: 'Create a Pool',
+                  href: '/pools/new',
+                  variant: 'primary',
+                }}
+              />
+              <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-[var(--color-border)] bg-[var(--color-surface-raised)] py-24 text-center">
+                <div className="flex size-12 items-center justify-center rounded-full bg-[var(--color-border)] text-[var(--color-text-muted)] mb-4">
+                  <SearchIcon />
+                </div>
+                <h3 className="text-base font-semibold">No results found</h3>
+                <p className="mt-1 text-sm text-[var(--color-text-muted)] max-w-sm">
+                  We couldn&apos;t find any pools matching your search criteria.
+                  Try adjusting your filters or search term.
+                </p>
+                <button
+                  onClick={handleClearFilters}
+                  className="mt-6 text-sm font-medium text-brand-600 hover:text-brand-700"
+                >
+                  Clear filters
+                </button>
               </div>
-              <h3 className="text-base font-semibold">No results found</h3>
-              <p className="mt-1 text-sm text-[var(--color-text-muted)] max-w-sm">
-                We couldn&apos;t find any pools matching your search criteria.
-                Try adjusting your filters or search term.
-              </p>
-              <button
-                onClick={handleClearFilters}
-                className="mt-6 text-sm font-medium text-brand-600 hover:text-brand-700"
-              >
-                Clear filters
-              </button>
-            </div>
+            </>
           ) : (
             <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
               {displayedPools.map((pool) => (

--- a/nevo_frontend/components/RateLimitNotice.tsx
+++ b/nevo_frontend/components/RateLimitNotice.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { isRateLimitError } from '@/lib/api-client';
+
+interface RateLimitNoticeProps {
+  error: unknown;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function RateLimitNotice({
+  error,
+  onRetry,
+  className = '',
+}: RateLimitNoticeProps) {
+  const rateLimitError = isRateLimitError(error) ? error : null;
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!rateLimitError) return;
+
+    function tick() {
+      setNow(Date.now());
+    }
+
+    tick();
+    const interval = window.setInterval(tick, 1000);
+    return () => window.clearInterval(interval);
+  }, [rateLimitError]);
+
+  if (!rateLimitError) return null;
+
+  const remainingMs = Math.max(0, rateLimitError.resetAt - now);
+  const remainingSeconds = Math.ceil(remainingMs / 1000);
+  const canRetry = remainingMs <= 0 && Boolean(onRetry);
+
+  return (
+    <div
+      role="alert"
+      className={`rounded-lg border border-warning bg-warning-light p-4 text-warning-dark ${className}`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold">Request paused</p>
+          <p className="mt-1 text-sm leading-5">{rateLimitError.message}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={!canRetry}
+          className="w-full rounded-md bg-warning-dark px-4 py-2 text-sm font-semibold text-warning-light transition-colors disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+        >
+          {remainingSeconds > 0 ? `Retry in ${remainingSeconds}s` : 'Retry now'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/nevo_frontend/components/RateLimitToast.tsx
+++ b/nevo_frontend/components/RateLimitToast.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { RATE_LIMIT_EVENT, type RateLimitNotification } from '@/lib/rate-limit';
+
+type ActiveNotification = RateLimitNotification & { id: number };
+
+export function RateLimitToast() {
+  const [notification, setNotification] = useState<ActiveNotification | null>(
+    null
+  );
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    function handleRateLimit(event: Event) {
+      const detail = (event as CustomEvent<RateLimitNotification>).detail;
+      setNotification({ ...detail, id: Date.now() });
+      setNow(Date.now());
+    }
+
+    window.addEventListener(RATE_LIMIT_EVENT, handleRateLimit);
+    return () => window.removeEventListener(RATE_LIMIT_EVENT, handleRateLimit);
+  }, []);
+
+  useEffect(() => {
+    if (!notification) return;
+
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    const dismissAfterMs = Math.max(
+      4_000,
+      notification.resetAt - Date.now() + 4_000
+    );
+    const timeout = window.setTimeout(
+      () => setNotification(null),
+      dismissAfterMs
+    );
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+    };
+  }, [notification]);
+
+  if (!notification) return null;
+
+  const remainingSeconds = Math.max(
+    0,
+    Math.ceil((notification.resetAt - now) / 1000)
+  );
+
+  return (
+    <div className="fixed inset-x-4 bottom-4 z-50 sm:inset-x-auto sm:right-6 sm:bottom-6 sm:w-full sm:max-w-sm">
+      <div
+        role="status"
+        aria-live="polite"
+        className="rounded-lg border border-warning bg-warning-light p-4 text-warning-dark shadow-lg"
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold">Too many requests</p>
+            <p className="mt-1 text-sm leading-5">{notification.message}</p>
+            <p className="mt-2 text-xs font-medium">
+              {remainingSeconds > 0
+                ? `Try again in ${remainingSeconds}s.`
+                : 'You can try again now.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setNotification(null)}
+            className="self-start rounded-md border border-warning/40 px-3 py-1.5 text-xs font-semibold transition-colors hover:bg-warning/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warning-dark"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nevo_frontend/components/index.ts
+++ b/nevo_frontend/components/index.ts
@@ -14,3 +14,5 @@ export * from './Skeleton';
 export * from './DonateModal';
 export * from './MobileMenu';
 export * from './EmptyState';
+export * from './RateLimitNotice';
+export * from './RateLimitToast';

--- a/nevo_frontend/hooks/useApi.ts
+++ b/nevo_frontend/hooks/useApi.ts
@@ -1,10 +1,24 @@
-import { useState, useCallback, useEffect } from 'react';
-import { ApiError, apiClient } from '../lib/api-client';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  ApiError,
+  RateLimitError,
+  apiClient,
+  getRateLimitRemainingMs,
+  isRateLimitError,
+} from '../lib/api-client';
+
+interface RateLimitState<T> {
+  error: RateLimitError;
+  remainingSeconds: number;
+  canRetry: boolean;
+  retry: () => Promise<T | null>;
+}
 
 interface UseApiResponse<T, Args extends unknown[] = unknown[]> {
   data: T | null;
   error: ApiError | Error | null;
   isLoading: boolean;
+  rateLimit: RateLimitState<T> | null;
   execute: (...args: Args) => Promise<T | null>;
   reset: () => void;
 }
@@ -20,12 +34,19 @@ export function useApi<T, Args extends unknown[] = unknown[]>(
   const [data, setData] = useState<T | null>(options.initialData ?? null);
   const [error, setError] = useState<ApiError | Error | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [rateLimitError, setRateLimitError] = useState<RateLimitError | null>(
+    null
+  );
+  const [rateLimitRemainingMs, setRateLimitRemainingMs] = useState(0);
+  const lastArgsRef = useRef<Args | null>(null);
 
   const execute = useCallback(
     async (...args: Args): Promise<T | null> => {
+      lastArgsRef.current = args;
       try {
         setIsLoading(true);
         setError(null);
+        setRateLimitError(null);
         const result = await apiFunction(...args);
         setData(result);
         if (options.onSuccess) {
@@ -35,6 +56,13 @@ export function useApi<T, Args extends unknown[] = unknown[]>(
       } catch (err) {
         const errorObject = err instanceof Error ? err : new Error(String(err));
         setError(errorObject);
+        if (isRateLimitError(errorObject)) {
+          setRateLimitError(errorObject);
+          setRateLimitRemainingMs(getRateLimitRemainingMs(errorObject));
+        } else {
+          setRateLimitError(null);
+          setRateLimitRemainingMs(0);
+        }
         if (options.onError) {
           options.onError(errorObject);
         }
@@ -46,9 +74,29 @@ export function useApi<T, Args extends unknown[] = unknown[]>(
     [apiFunction, options]
   );
 
+  useEffect(() => {
+    if (!rateLimitError) return;
+    const currentError = rateLimitError;
+
+    function tick() {
+      setRateLimitRemainingMs(getRateLimitRemainingMs(currentError));
+    }
+
+    tick();
+    const interval = window.setInterval(tick, 1000);
+    return () => window.clearInterval(interval);
+  }, [rateLimitError]);
+
+  const retry = useCallback(() => {
+    if (!lastArgsRef.current) return Promise.resolve(null);
+    return execute(...lastArgsRef.current);
+  }, [execute]);
+
   const reset = useCallback(() => {
     setData(options.initialData ?? null);
     setError(null);
+    setRateLimitError(null);
+    setRateLimitRemainingMs(0);
     setIsLoading(false);
   }, [options.initialData]);
 
@@ -56,6 +104,14 @@ export function useApi<T, Args extends unknown[] = unknown[]>(
     data,
     error,
     isLoading,
+    rateLimit: rateLimitError
+      ? {
+          error: rateLimitError,
+          remainingSeconds: Math.ceil(rateLimitRemainingMs / 1000),
+          canRetry: rateLimitRemainingMs <= 0,
+          retry,
+        }
+      : null,
     execute,
     reset,
   };

--- a/nevo_frontend/lib/api-client.ts
+++ b/nevo_frontend/lib/api-client.ts
@@ -1,3 +1,14 @@
+import {
+  ClientRateLimiter,
+  DEFAULT_RATE_LIMIT_OPTIONS,
+  RateLimitError,
+  type RateLimitOptions,
+  isRateLimitError,
+  notifyRateLimit,
+  parseRetryAfterHeader,
+  resolveRateLimitOptions,
+} from './rate-limit';
+
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 export interface RequestConfig extends Omit<RequestInit, 'method' | 'body'> {
@@ -7,6 +18,11 @@ export interface RequestConfig extends Omit<RequestInit, 'method' | 'body'> {
   retryDelay?: number;
   body?: unknown;
   requireAuth?: boolean;
+  rateLimit?: false | Partial<RateLimitOptions>;
+  rateLimitKey?: string;
+  skipRateLimitNotification?: boolean;
+  cacheResponse?: boolean;
+  cacheTtlMs?: number;
 }
 
 export class ApiError extends Error {
@@ -22,23 +38,45 @@ export class ApiError extends Error {
 
 type Interceptor<T> = (data: T) => T | Promise<T>;
 
-class ApiClient {
+type PreparedRequestConfig = RequestConfig & {
+  url: string;
+  method: string;
+  headers: Headers;
+  body?: BodyInit;
+};
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 15_000;
+const DEFAULT_RATE_LIMIT_KEY = 'api';
+
+export class ApiClient {
   private baseURL: string;
   private defaultTimeout: number;
+  private defaultRateLimit: RateLimitOptions;
+  private rateLimiter: ClientRateLimiter;
+  private responseCache = new Map<string, CacheEntry<unknown>>();
   private activeRequests = 0;
   private loadingListeners: Set<(loading: boolean) => void> = new Set();
 
-  public requestInterceptors: Interceptor<
-    RequestConfig & { url: string; method: string }
-  >[] = [];
+  public requestInterceptors: Interceptor<PreparedRequestConfig>[] = [];
   public responseInterceptors: Interceptor<Response>[] = [];
 
-  constructor(baseURL: string = '', defaultTimeout: number = 10000) {
+  constructor(
+    baseURL: string = '',
+    defaultTimeout: number = 10000,
+    rateLimit: Partial<RateLimitOptions> = DEFAULT_RATE_LIMIT_OPTIONS
+  ) {
     this.baseURL =
       baseURL ||
       process.env.NEXT_PUBLIC_API_BASE_URL ||
       'http://localhost:3000';
     this.defaultTimeout = defaultTimeout;
+    this.defaultRateLimit = resolveRateLimitOptions(rateLimit);
+    this.rateLimiter = new ClientRateLimiter();
   }
 
   private startRequest() {
@@ -81,9 +119,7 @@ class ApiClient {
   }
 
   // Interceptors
-  addRequestInterceptor(
-    interceptor: Interceptor<RequestConfig & { url: string; method: string }>
-  ) {
+  addRequestInterceptor(interceptor: Interceptor<PreparedRequestConfig>) {
     this.requestInterceptors.push(interceptor);
   }
 
@@ -91,9 +127,7 @@ class ApiClient {
     this.responseInterceptors.push(interceptor);
   }
 
-  private async applyRequestInterceptors(
-    config: RequestConfig & { url: string; method: string }
-  ) {
+  private async applyRequestInterceptors(config: PreparedRequestConfig) {
     let currentConfig = { ...config };
     for (const interceptor of this.requestInterceptors) {
       currentConfig = await interceptor(currentConfig);
@@ -109,6 +143,155 @@ class ApiClient {
     return currentResponse;
   }
 
+  public getRateLimitStatus(
+    key: string = DEFAULT_RATE_LIMIT_KEY,
+    options: Partial<RateLimitOptions> = {}
+  ) {
+    return this.rateLimiter.getStatus(
+      key,
+      resolveRateLimitOptions({ ...this.defaultRateLimit, ...options })
+    );
+  }
+
+  public clearResponseCache() {
+    this.responseCache.clear();
+  }
+
+  public resetRateLimits(key?: string) {
+    this.rateLimiter.reset(key);
+  }
+
+  private buildUrl(
+    endpoint: string,
+    params?: Record<string, string | number | boolean | undefined>
+  ) {
+    let url = `${this.baseURL}${endpoint}`;
+
+    if (!params) return url;
+
+    const searchParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) {
+        searchParams.append(key, String(value));
+      }
+    });
+
+    const queryString = searchParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+
+    return url;
+  }
+
+  private buildRequestConfig(
+    endpoint: string,
+    method: HttpMethod,
+    config: RequestConfig
+  ): PreparedRequestConfig {
+    const { params, body, ...customInit } = config;
+    const headers = new Headers(customInit.headers || {});
+
+    if (
+      !headers.has('Content-Type') &&
+      body !== undefined &&
+      !(body instanceof FormData)
+    ) {
+      headers.set('Content-Type', 'application/json');
+    }
+    if (!headers.has('Accept')) {
+      headers.set('Accept', 'application/json');
+    }
+
+    return {
+      ...customInit,
+      url: this.buildUrl(endpoint, params),
+      method,
+      headers,
+      body:
+        body !== undefined
+          ? body instanceof FormData
+            ? body
+            : JSON.stringify(body)
+          : undefined,
+    } as PreparedRequestConfig;
+  }
+
+  private getCacheKey(config: PreparedRequestConfig) {
+    const walletKey = config.headers.get('X-Wallet-Pubkey') ?? 'anonymous';
+    return `${config.method}:${config.url}:wallet=${walletKey}`;
+  }
+
+  private getCachedResponse<T>(key: string): T | undefined {
+    const cached = this.responseCache.get(key);
+    if (!cached) return undefined;
+
+    if (Date.now() >= cached.expiresAt) {
+      this.responseCache.delete(key);
+      return undefined;
+    }
+
+    return cached.data as T;
+  }
+
+  private setCachedResponse<T>(key: string, data: T, cacheTtlMs: number) {
+    if (cacheTtlMs <= 0) return;
+
+    this.responseCache.set(key, {
+      data,
+      expiresAt: Date.now() + cacheTtlMs,
+    });
+  }
+
+  private enforceRateLimit(
+    config: PreparedRequestConfig,
+    endpoint: string,
+    notify: boolean
+  ) {
+    if (config.rateLimit === false) return;
+
+    const options = resolveRateLimitOptions({
+      ...this.defaultRateLimit,
+      ...config.rateLimit,
+    });
+    const result = this.rateLimiter.consume(
+      config.rateLimitKey ?? DEFAULT_RATE_LIMIT_KEY,
+      options
+    );
+
+    if (!result.allowed) {
+      const error = new RateLimitError(result, endpoint);
+      if (notify) {
+        notifyRateLimit(error);
+      }
+      throw error;
+    }
+  }
+
+  private createServerRateLimitError(
+    response: Response,
+    endpoint: string
+  ): RateLimitError {
+    const retryAfterMs =
+      parseRetryAfterHeader(response.headers.get('Retry-After')) ??
+      this.defaultRateLimit.windowMs;
+
+    return new RateLimitError(
+      {
+        ...this.defaultRateLimit,
+        allowed: false,
+        remaining: 0,
+        resetAt: Date.now() + retryAfterMs,
+        retryAfterMs,
+      },
+      endpoint
+    );
+  }
+
+  private getBackoffMs(retryDelay: number, attempt: number) {
+    return retryDelay * 2 ** Math.max(0, attempt - 1);
+  }
+
   // Core request method
   async request<T>(
     endpoint: string,
@@ -118,53 +301,31 @@ class ApiClient {
     this.startRequest();
     try {
       const {
-        params,
         timeout = this.defaultTimeout,
         retries = 3,
         retryDelay = 1000,
-        body,
-        ...customInit
+        cacheResponse = true,
+        cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+        skipRateLimitNotification = false,
       } = config;
 
-      let url = `${this.baseURL}${endpoint}`;
-
-      // Add query params
-      if (params) {
-        const searchParams = new URLSearchParams();
-        Object.entries(params).forEach(([key, value]) => {
-          if (value !== undefined) {
-            searchParams.append(key, String(value));
-          }
-        });
-        const queryString = searchParams.toString();
-        if (queryString) {
-          url += `?${queryString}`;
-        }
-      }
-
-      // Default headers
-      const headers = new Headers(customInit.headers || {});
-      if (!headers.has('Content-Type') && body && !(body instanceof FormData)) {
-        headers.set('Content-Type', 'application/json');
-      }
-      if (!headers.has('Accept')) {
-        headers.set('Accept', 'application/json');
-      }
-
-      let requestConfig: RequestConfig & { url: string; method: string } = {
-        ...customInit,
-        url,
-        method,
-        headers,
-        body: body
-          ? body instanceof FormData
-            ? body
-            : JSON.stringify(body)
-          : undefined,
-      } as RequestConfig & { url: string; method: string };
+      let requestConfig = this.buildRequestConfig(endpoint, method, config);
 
       // Apply request interceptors
       requestConfig = await this.applyRequestInterceptors(requestConfig);
+
+      const shouldCache = method === 'GET' && cacheResponse;
+      const cacheKey = shouldCache ? this.getCacheKey(requestConfig) : null;
+      if (cacheKey) {
+        const cached = this.getCachedResponse<T>(cacheKey);
+        if (cached !== undefined) return cached;
+      }
+
+      this.enforceRateLimit(
+        requestConfig,
+        endpoint,
+        !skipRateLimitNotification
+      );
 
       let attempt = 0;
       while (attempt <= retries) {
@@ -188,6 +349,17 @@ class ApiClient {
           // Apply response interceptors
           response = await this.applyResponseInterceptors(response);
 
+          if (response.status === 429) {
+            const rateLimitError = this.createServerRateLimitError(
+              response,
+              endpoint
+            );
+            if (!skipRateLimitNotification) {
+              notifyRateLimit(rateLimitError);
+            }
+            throw rateLimitError;
+          }
+
           if (!response.ok) {
             let errorData;
             try {
@@ -203,9 +375,18 @@ class ApiClient {
             return {} as T;
           }
 
-          return await response.json();
+          const data = (await response.json()) as T;
+          if (cacheKey) {
+            this.setCachedResponse(cacheKey, data, cacheTtlMs);
+          }
+
+          return data;
         } catch (error) {
           clearTimeout(timeoutId);
+
+          if (isRateLimitError(error)) {
+            throw error;
+          }
 
           let finalError = error as Error | ApiError;
           if (
@@ -221,8 +402,7 @@ class ApiClient {
           if (
             finalError instanceof ApiError &&
             finalError.status >= 400 &&
-            finalError.status < 500 &&
-            finalError.status !== 429
+            finalError.status < 500
           ) {
             throw finalError;
           }
@@ -234,7 +414,7 @@ class ApiClient {
 
           // Wait before retrying
           await new Promise((resolve) =>
-            setTimeout(resolve, retryDelay * attempt)
+            setTimeout(resolve, this.getBackoffMs(retryDelay, attempt))
           );
         }
       }
@@ -264,6 +444,11 @@ class ApiClient {
 }
 
 export const apiClient = new ApiClient();
+export {
+  RateLimitError,
+  getRateLimitRemainingMs,
+  isRateLimitError,
+} from './rate-limit';
 
 // Add default auth interceptor for wallet signature
 apiClient.addRequestInterceptor((config) => {

--- a/nevo_frontend/lib/rate-limit.ts
+++ b/nevo_frontend/lib/rate-limit.ts
@@ -1,0 +1,214 @@
+export interface RateLimitOptions {
+  maxRequests: number;
+  windowMs: number;
+}
+
+export interface RateLimitResult extends RateLimitOptions {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+  retryAfterMs: number;
+}
+
+interface WindowCounter {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimitNotification {
+  message: string;
+  retryAfterMs: number;
+  resetAt: number;
+  limit: number;
+  endpoint?: string;
+}
+
+export const RATE_LIMIT_EVENT = 'nevo:api-rate-limit';
+
+const DEFAULT_MAX_REQUESTS = 30;
+const DEFAULT_WINDOW_MS = 60_000;
+
+function readPositiveEnvNumber(name: string, fallback: number): number {
+  if (typeof process === 'undefined') return fallback;
+  const value = process.env[name];
+  if (!value) return fallback;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export const DEFAULT_RATE_LIMIT_OPTIONS: RateLimitOptions = {
+  maxRequests: readPositiveEnvNumber(
+    'NEXT_PUBLIC_API_RATE_LIMIT_MAX_REQUESTS',
+    DEFAULT_MAX_REQUESTS
+  ),
+  windowMs: readPositiveEnvNumber(
+    'NEXT_PUBLIC_API_RATE_LIMIT_WINDOW_MS',
+    DEFAULT_WINDOW_MS
+  ),
+};
+
+export function resolveRateLimitOptions(
+  options: Partial<RateLimitOptions> = {}
+): RateLimitOptions {
+  return {
+    maxRequests:
+      typeof options.maxRequests === 'number' && options.maxRequests > 0
+        ? Math.floor(options.maxRequests)
+        : DEFAULT_RATE_LIMIT_OPTIONS.maxRequests,
+    windowMs:
+      typeof options.windowMs === 'number' && options.windowMs > 0
+        ? Math.floor(options.windowMs)
+        : DEFAULT_RATE_LIMIT_OPTIONS.windowMs,
+  };
+}
+
+export class RateLimitError extends Error {
+  readonly status = 429;
+  readonly retryAfterMs: number;
+  readonly resetAt: number;
+  readonly remaining: number;
+  readonly limit: number;
+  readonly windowMs: number;
+  readonly endpoint?: string;
+
+  constructor(result: RateLimitResult, endpoint?: string) {
+    const seconds = Math.max(1, Math.ceil(result.retryAfterMs / 1000));
+    super(
+      `You're sending requests too quickly. Please try again in ${seconds} second${
+        seconds === 1 ? '' : 's'
+      }.`
+    );
+    this.name = 'RateLimitError';
+    this.retryAfterMs = result.retryAfterMs;
+    this.resetAt = result.resetAt;
+    this.remaining = result.remaining;
+    this.limit = result.maxRequests;
+    this.windowMs = result.windowMs;
+    this.endpoint = endpoint;
+  }
+}
+
+export function isRateLimitError(error: unknown): error is RateLimitError {
+  return (
+    error instanceof RateLimitError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      error.name === 'RateLimitError' &&
+      'retryAfterMs' in error &&
+      'resetAt' in error)
+  );
+}
+
+export function getRateLimitRemainingMs(error: RateLimitError): number {
+  return Math.max(0, error.resetAt - Date.now());
+}
+
+export function parseRetryAfterHeader(
+  retryAfter: string | null,
+  now: number = Date.now()
+): number | null {
+  if (!retryAfter) return null;
+
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  const dateMs = Date.parse(retryAfter);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(0, dateMs - now);
+  }
+
+  return null;
+}
+
+export function notifyRateLimit(error: RateLimitError): void {
+  if (typeof window === 'undefined') return;
+
+  const detail: RateLimitNotification = {
+    message: error.message,
+    retryAfterMs: error.retryAfterMs,
+    resetAt: error.resetAt,
+    limit: error.limit,
+    endpoint: error.endpoint,
+  };
+
+  window.dispatchEvent(new CustomEvent(RATE_LIMIT_EVENT, { detail }));
+}
+
+export class ClientRateLimiter {
+  private windows = new Map<string, WindowCounter>();
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  consume(key: string, options: RateLimitOptions): RateLimitResult {
+    const currentTime = this.now();
+    const window = this.getWindow(key, currentTime, options.windowMs);
+
+    if (window.count >= options.maxRequests) {
+      return {
+        ...options,
+        allowed: false,
+        remaining: 0,
+        resetAt: window.resetAt,
+        retryAfterMs: Math.max(0, window.resetAt - currentTime),
+      };
+    }
+
+    window.count += 1;
+
+    return {
+      ...options,
+      allowed: true,
+      remaining: Math.max(0, options.maxRequests - window.count),
+      resetAt: window.resetAt,
+      retryAfterMs: 0,
+    };
+  }
+
+  getStatus(key: string, options: RateLimitOptions): RateLimitResult {
+    const currentTime = this.now();
+    const window = this.getWindow(key, currentTime, options.windowMs);
+
+    return {
+      ...options,
+      allowed: window.count < options.maxRequests,
+      remaining: Math.max(0, options.maxRequests - window.count),
+      resetAt: window.resetAt,
+      retryAfterMs:
+        window.count >= options.maxRequests
+          ? Math.max(0, window.resetAt - currentTime)
+          : 0,
+    };
+  }
+
+  reset(key?: string): void {
+    if (key) {
+      this.windows.delete(key);
+      return;
+    }
+
+    this.windows.clear();
+  }
+
+  private getWindow(
+    key: string,
+    currentTime: number,
+    windowMs: number
+  ): WindowCounter {
+    const existing = this.windows.get(key);
+
+    if (existing && currentTime < existing.resetAt) {
+      return existing;
+    }
+
+    const freshWindow = {
+      count: 0,
+      resetAt: currentTime + windowMs,
+    };
+    this.windows.set(key, freshWindow);
+    return freshWindow;
+  }
+}

--- a/nevo_frontend/lib/stellar.ts
+++ b/nevo_frontend/lib/stellar.ts
@@ -1,17 +1,71 @@
+import {
+  ClientRateLimiter,
+  RateLimitError,
+  notifyRateLimit,
+  parseRetryAfterHeader,
+  resolveRateLimitOptions,
+} from './rate-limit';
+
 export interface AccountBalances {
   xlm: string;
   usdc: string;
 }
 
 const HORIZON = 'https://horizon.stellar.org';
+const ZERO_BALANCES: AccountBalances = { xlm: '0', usdc: '0' };
+const HORIZON_RATE_LIMIT = resolveRateLimitOptions({
+  maxRequests: 60,
+  windowMs: 60_000,
+});
+const horizonRateLimiter = new ClientRateLimiter();
+
+function createHorizonRateLimitError(
+  retryAfterMs: number,
+  endpoint: string
+): RateLimitError {
+  return new RateLimitError(
+    {
+      ...HORIZON_RATE_LIMIT,
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + retryAfterMs,
+      retryAfterMs,
+    },
+    endpoint
+  );
+}
+
+function enforceHorizonRateLimit(endpoint: string): void {
+  const result = horizonRateLimiter.consume(
+    'stellar:horizon',
+    HORIZON_RATE_LIMIT
+  );
+  if (!result.allowed) {
+    const error = new RateLimitError(result, endpoint);
+    notifyRateLimit(error);
+    throw error;
+  }
+}
 
 /** Fetches XLM and USDC balances for a Stellar public key via Horizon. */
 export async function getAccountBalances(
   publicKey: string
 ): Promise<AccountBalances> {
+  const endpoint = `${HORIZON}/accounts/${publicKey}`;
+
   try {
-    const res = await fetch(`${HORIZON}/accounts/${publicKey}`);
-    if (!res.ok) return { xlm: '0', usdc: '0' };
+    enforceHorizonRateLimit(endpoint);
+
+    const res = await fetch(endpoint);
+    if (res.status === 429) {
+      const retryAfterMs =
+        parseRetryAfterHeader(res.headers.get('Retry-After')) ??
+        HORIZON_RATE_LIMIT.windowMs;
+      notifyRateLimit(createHorizonRateLimitError(retryAfterMs, endpoint));
+      return ZERO_BALANCES;
+    }
+
+    if (!res.ok) return ZERO_BALANCES;
     const data = await res.json();
     let xlm = '0';
     let usdc = '0';
@@ -21,6 +75,6 @@ export async function getAccountBalances(
     }
     return { xlm, usdc };
   } catch {
-    return { xlm: '0', usdc: '0' };
+    return ZERO_BALANCES;
   }
 }

--- a/nevo_frontend/next.config.ts
+++ b/nevo_frontend/next.config.ts
@@ -9,13 +9,12 @@ const nextConfig: NextConfig = {
   productionBrowserSourceMaps: false,
   poweredByHeader: false,
   reactStrictMode: true,
-  swcMinify: true,
   experimental: {
     optimizePackageImports: ['zustand', '@stellar/freighter-api'],
   },
 };
 
-export default withSentryConfig(nextConfig, {
+const sentryOptions = {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   silent: !process.env.CI,
@@ -25,4 +24,6 @@ export default withSentryConfig(nextConfig, {
   hideSourceMaps: true,
   disableServerWebpackPlugin: true,
   disableClientWebpackPlugin: true,
-});
+};
+
+export default withSentryConfig(nextConfig, sentryOptions);


### PR DESCRIPTION
closes #584 
Summary
Added a shared client-side rate limiter for frontend API calls.
Integrated rate-limit enforcement into the frontend API client.
Added handling for server 429 responses with retry timing.
Added GET response caching to reduce repeated API calls.
Added exponential backoff for retryable request failures.
Added responsive rate-limit toast and inline retry notice components.
Added Stellar Horizon rate-limit handling for wallet balance lookups.
Added focused tests for API client and Stellar Horizon rate-limit behavior.
Fixed minimal frontend build blockers discovered during validation.

Reason
This prevents excessive frontend API calls, improves handling of rate-limited responses, and gives users clear feedback with retry timing instead of silent failures or repeated failed requests.