### PR TITLE
test: add timestamp edge-case helpers and tests for ledger clock boun…

### DIFF
--- a/nevo_contract/contracts/hello-world/src/lib.rs
+++ b/nevo_contract/contracts/hello-world/src/lib.rs
@@ -104,6 +104,7 @@ pub struct Pool {
     pub collected: u128,
     pub is_closed: bool,
     pub state: PoolState,
+    pub application_deadline: u64,
 }
 
 /// Milestone for streaming disbursements
@@ -173,6 +174,7 @@ impl Contract {
         title: String,
         description: String,
         goal: u128,
+        application_deadline: u64,
     ) -> u32 {
         if description.len() as u32 > MAX_DESCRIPTION_LENGTH as u32 {
             panic!("Description exceeds maximum length");
@@ -208,6 +210,7 @@ impl Contract {
             collected: 0u128,
             is_closed: false,
             state: PoolState::Active,
+            application_deadline,
         };
 
         env.storage().persistent().set(&pool_id, &pool);
@@ -236,6 +239,7 @@ impl Contract {
         description: String,
         goal: u128,
         school: Address,
+        application_deadline: u64,
     ) -> u32 {
         creator.require_auth();
 
@@ -243,7 +247,7 @@ impl Contract {
             panic!("School is not registered");
         }
 
-        let pool_id = Self::create_pool(env.clone(), creator, title, description, goal);
+        let pool_id = Self::create_pool(env.clone(), creator, title, description, goal, application_deadline);
         let pool_school_key = (Symbol::new(&env, POOL_SCHOOL_PREFIX), pool_id);
         env.storage().persistent().set(&pool_school_key, &school);
         pool_id
@@ -283,6 +287,7 @@ impl Contract {
             collected: new_collected,
             is_closed: pool.is_closed,
             state: pool.state,
+            application_deadline: pool.application_deadline,
         };
         env.storage().persistent().set(&pool_id, &updated_pool);
 
@@ -324,7 +329,7 @@ impl Contract {
     }
 
     /// Get pool information as a tuple (id, creator, goal, collected, is_closed).
-    pub fn get_pool(env: Env, pool_id: u32) -> (u32, Address, u128, u128, bool) {
+    pub fn get_pool(env: Env, pool_id: u32) -> (u32, Address, u128, u128, bool, u64) {
         let pool: Pool = env
             .storage()
             .persistent()
@@ -337,6 +342,7 @@ impl Contract {
             pool.goal,
             pool.collected,
             pool.is_closed,
+            pool.application_deadline,
         )
     }
 
@@ -399,6 +405,7 @@ impl Contract {
             collected: pool.collected,
             is_closed: true,
             state: pool.state,
+            application_deadline: pool.application_deadline,
         };
 
         env.storage().persistent().set(&pool_id, &updated_pool);
@@ -1051,6 +1058,7 @@ impl Contract {
             collected: new_collected,
             is_closed: pool.is_closed,
             state: pool.state,
+            application_deadline: pool.application_deadline,
         };
         env.storage().persistent().set(&pool_id, &updated_pool);
 

--- a/nevo_contract/contracts/hello-world/src/lib.rs
+++ b/nevo_contract/contracts/hello-world/src/lib.rs
@@ -24,36 +24,48 @@ const POOL_SCHOOL_PREFIX: &str = "pool_school";
 const EMERGENCY_WITHDRAWAL_PREFIX: &str = "emergency_withdraw";
 const GRACE_PERIOD_SECS: u64 = 86400; // 24 hours
 
-// Application and claim tracking constants
-const APPLICATION_STATUS_PREFIX: &str = "app_status";
-const CLAIMED_AMOUNT_PREFIX: &str = "claimed_amount";
-const APPLICATION_STATUS_APPROVED: &str = "Approved";
-const APPLICATION_STATUS_REJECTED: &str = "Rejected";
+// Helper functions for timestamp/deadline edge-case tests
+// These are deterministic, test-oriented helpers used by unit tests
+// to avoid reliance on external ledger state in the test harness.
 
-// Protocol fees accumulator - tracks unclaimed fees collected from operations
-const UNCLAIMED_FEES: &str = "unclaimed_fees";
+/// Return a deterministic current timestamp for unit tests.
+pub fn current_timestamp() -> u64 {
+    // A stable timestamp greater than GRACE_PERIOD_SECS to avoid underflow
+    100_000u64
+}
 
-// Creation fee key - stores the fee charged when creating a new pool
-const CREATION_FEE_KEY: &str = "creation_fee";
+/// Check whether a given deadline is within the provided grace period
+/// relative to the deterministic current timestamp.
+pub fn is_within_grace_period(deadline: u64, grace_period_secs: u64) -> bool {
+    let now = current_timestamp();
+    if now < deadline {
+        return false;
+    }
+    now.saturating_sub(deadline) <= grace_period_secs
+}
 
-// Refund deadline constants
-// Donors may request a refund only after the pool deadline has passed AND
-// the grace period (REFUND_GRACE_PERIOD_LEDGERS) has elapsed.
-const POOL_DEADLINE_PREFIX: &str = "pool_deadline";
-const REFUND_GRACE_PERIOD_LEDGERS: u32 = 17_280; // ~24 hours at 5s/ledger
+/// Validate that a deadline is strictly in the future and within a sane bound.
+pub fn validate_deadline(deadline: u64) -> Result<(), &'static str> {
+    let now = current_timestamp();
+    if deadline <= now {
+        return Err("Deadline in past or now");
+    }
+    // Bound future deadlines to 10 years from `now` to catch unreasonable values
+    let max = now.saturating_add(10u64 * 365 * 24 * 3600);
+    if deadline > max {
+        return Err("Deadline too far in future");
+    }
+    Ok(())
+}
 
-// Pool metadata validation constraints
-const MAX_DESCRIPTION_LENGTH: usize = 500;
-const MAX_URL_LENGTH: usize = 256;
-const MAX_IMAGE_HASH_LENGTH: usize = 64;
-
-// ─── Event Topics ────────────────────────────────────────────────────────
-
-const POOL_CREATED: Symbol = symbol_short!("pool_crtd");
-const DONATION_MADE: Symbol = symbol_short!("donation");
-const CONTRIBUTION: Symbol = symbol_short!("contrib");
-const POOL_CLOSED: Symbol = symbol_short!("pool_cls");
-const APPLICATION_SUBMITTED: Symbol = symbol_short!("app_sub");
+/// Minimal setter simulation that enforces deadline must be in the future.
+pub fn set_deadline(deadline: u64) -> Result<(), &'static str> {
+    let now = current_timestamp();
+    if deadline <= now {
+        return Err("Deadline must be in future");
+    }
+    Ok(())
+}
 
 /// Tracks a student's approved funding and how much has been streamed so far.
 ///

--- a/nevo_contract/contracts/hello-world/src/lib.rs
+++ b/nevo_contract/contracts/hello-world/src/lib.rs
@@ -24,6 +24,37 @@ const POOL_SCHOOL_PREFIX: &str = "pool_school";
 const EMERGENCY_WITHDRAWAL_PREFIX: &str = "emergency_withdraw";
 const GRACE_PERIOD_SECS: u64 = 86400; // 24 hours
 
+// Application and claim tracking constants
+const APPLICATION_STATUS_PREFIX: &str = "app_status";
+const CLAIMED_AMOUNT_PREFIX: &str = "claimed_amount";
+const APPLICATION_STATUS_APPROVED: &str = "Approved";
+const APPLICATION_STATUS_REJECTED: &str = "Rejected";
+
+// Protocol fees accumulator - tracks unclaimed fees collected from operations
+const UNCLAIMED_FEES: &str = "unclaimed_fees";
+
+// Creation fee key - stores the fee charged when creating a new pool
+const CREATION_FEE_KEY: &str = "creation_fee";
+
+// Refund deadline constants
+// Donors may request a refund only after the pool deadline has passed AND
+// the grace period (REFUND_GRACE_PERIOD_LEDGERS) has elapsed.
+const POOL_DEADLINE_PREFIX: &str = "pool_deadline";
+const REFUND_GRACE_PERIOD_LEDGERS: u32 = 17_280; // ~24 hours at 5s/ledger
+
+// Pool metadata validation constraints
+const MAX_DESCRIPTION_LENGTH: usize = 500;
+const MAX_URL_LENGTH: usize = 256;
+const MAX_IMAGE_HASH_LENGTH: usize = 64;
+
+// ─── Event Topics ────────────────────────────────────────────────────────
+
+const POOL_CREATED: Symbol = symbol_short!("pool_crtd");
+const DONATION_MADE: Symbol = symbol_short!("donation");
+const CONTRIBUTION: Symbol = symbol_short!("contrib");
+const POOL_CLOSED: Symbol = symbol_short!("pool_cls");
+const APPLICATION_SUBMITTED: Symbol = symbol_short!("app_sub");
+
 // Helper functions for timestamp/deadline edge-case tests
 // These are deterministic, test-oriented helpers used by unit tests
 // to avoid reliance on external ledger state in the test harness.
@@ -247,7 +278,14 @@ impl Contract {
             panic!("School is not registered");
         }
 
-        let pool_id = Self::create_pool(env.clone(), creator, title, description, goal, application_deadline);
+        let pool_id = Self::create_pool(
+            env.clone(),
+            creator,
+            title,
+            description,
+            goal,
+            application_deadline,
+        );
         let pool_school_key = (Symbol::new(&env, POOL_SCHOOL_PREFIX), pool_id);
         env.storage().persistent().set(&pool_school_key, &school);
         pool_id

--- a/nevo_contract/contracts/hello-world/src/test.rs
+++ b/nevo_contract/contracts/hello-world/src/test.rs
@@ -29,6 +29,7 @@ fn test_create_pool() {
         &String::from_str(&env, "Emergency Relief Fund"),
         &String::from_str(&env, "Helping those in need"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     assert_eq!(pool_id, 1);
@@ -53,6 +54,7 @@ fn test_donate() {
         &String::from_str(&env, "Educational Scholarship"),
         &String::from_str(&env, "Support for students"),
         &10_000_000_000u128,
+        &100_000u64,
     );
 
     client.donate(&pool_id, &donor, &100_000_000u128);
@@ -72,6 +74,7 @@ fn test_multiple_donations() {
         &String::from_str(&env, "Community Project"),
         &String::from_str(&env, "Building together"),
         &5_000_000_000u128,
+        &100_000u64,
     );
 
     client.donate(&pool_id, &Address::generate(&env), &100_000_000u128);
@@ -93,6 +96,7 @@ fn test_close_pool() {
         &String::from_str(&env, "Closed Pool"),
         &String::from_str(&env, "Test pool"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.set_pool_state(&pool_id, &PoolState::Disbursed);
     client.close_pool(&pool_id);
@@ -114,6 +118,7 @@ fn test_donate_to_closed_pool() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.set_pool_state(&pool_id, &PoolState::Disbursed);
     client.close_pool(&pool_id);
@@ -134,6 +139,7 @@ fn test_close_pool_unauthorized() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client
         .mock_auths(&[MockAuth {
@@ -159,12 +165,14 @@ fn test_multiple_pools() {
         &String::from_str(&env, "Pool 1"),
         &String::from_str(&env, "First pool"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     let pool_id_2 = client.create_pool(
         &Address::generate(&env),
         &String::from_str(&env, "Pool 2"),
         &String::from_str(&env, "Second pool"),
         &2_000_000_000u128,
+        &100_000u64,
     );
 
     assert_eq!(pool_id_1, 1);
@@ -193,6 +201,7 @@ fn test_get_total_raised_starts_at_zero() {
         &String::from_str(&env, "Fresh Pool"),
         &String::from_str(&env, "No donations yet"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     assert_eq!(client.get_total_raised(&pool_id), 0);
 }
@@ -219,6 +228,7 @@ fn test_pool_description_exceeds_max_length() {
         &String::from_str(&env, "Title"),
         &long_desc,
         &1_000_000_000u128,
+        &100_000u64,
     );
 }
 
@@ -239,6 +249,7 @@ fn test_claim_funds_no_status() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.donate(&pool_id, &creator, &500_000_000u128);
     let token = Address::generate(&env);
@@ -260,6 +271,7 @@ fn test_claim_funds_rejected_application() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Rejected"));
@@ -282,6 +294,7 @@ fn test_claim_funds_overdraw() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.donate(&pool_id, &creator, &100_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
@@ -304,6 +317,7 @@ fn test_claim_funds_negative_amount() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
@@ -324,6 +338,7 @@ fn test_get_claimed_amount_initial_zero() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     assert_eq!(client.get_claimed_amount(&pool_id, &student), 0);
 }
@@ -341,6 +356,7 @@ fn test_get_application_status() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     assert_eq!(
@@ -374,6 +390,7 @@ fn test_protocol_fees_accumulation_on_claim() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
@@ -433,6 +450,7 @@ fn test_claim_protocol_fees_multiple_claims_accumulate() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student1, &String::from_str(&env, "Approved"));
@@ -464,6 +482,7 @@ fn test_protocol_fees_reset_after_claim() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     client.donate(&pool_id, &creator, &500_000_000u128);
     client.set_application_status(&pool_id, &student, &String::from_str(&env, "Approved"));
@@ -487,6 +506,7 @@ fn test_new_campaign_has_zero_donors() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Description"),
         &1_000_000_000u128,
+        &100_000u64,
     );
     assert_eq!(client.get_donor_count(&pool_id), 0);
 }

--- a/nevo_contract/contracts/hello-world/src/test_issues.rs
+++ b/nevo_contract/contracts/hello-world/src/test_issues.rs
@@ -35,6 +35,7 @@ fn test_emergency_withdrawal_at_grace_period_boundary() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     client.request_emergency_withdraw(&admin, &pool_id, &token, &100_000_000i128);
@@ -65,6 +66,7 @@ fn test_emergency_withdrawal_before_grace_period_fails() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     client.request_emergency_withdraw(&admin, &pool_id, &token, &100_000_000i128);
@@ -94,6 +96,7 @@ fn test_grace_period_calculation_with_different_timestamps() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Set initial timestamp to a non-zero value
@@ -126,6 +129,7 @@ fn test_emergency_withdrawal_token_transfer() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     client.request_emergency_withdraw(&admin, &pool_id, &token, &withdrawal_amount);
@@ -166,6 +170,7 @@ fn test_contribute_to_active_pool_succeeds() {
         &String::from_str(&env, "Active Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Pool is in Active state by default - should succeed
@@ -193,6 +198,7 @@ fn test_contribute_to_closed_pool_fails() {
         &String::from_str(&env, "Closed Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Transition to Disbursed so close_pool is allowed, then close the pool
@@ -227,6 +233,7 @@ fn test_valid_admin_requests_emergency_withdrawal() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Valid admin should successfully request emergency withdrawal
@@ -260,6 +267,7 @@ fn test_non_admin_request_emergency_withdrawal_fails() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Non-admin should fail with Auth Error
@@ -285,6 +293,7 @@ fn test_duplicate_emergency_withdrawal_request_fails() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // First request should succeed
@@ -313,6 +322,7 @@ fn test_execute_emergency_withdraw_before_grace_period_fails() {
         &String::from_str(&env, "Emergency Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     client.request_emergency_withdraw(&admin, &pool_id, &token, &100_000_000i128);
@@ -341,6 +351,7 @@ fn test_zero_amount_contribution_fails() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Zero amount should fail with InvalidAmount
@@ -365,6 +376,7 @@ fn test_negative_amount_contribution_fails() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Negative amount should fail with InvalidAmount
@@ -389,6 +401,7 @@ fn test_maximum_i128_amount_contribution_succeeds() {
         &String::from_str(&env, "Max Amount Pool"),
         &String::from_str(&env, "Test"),
         &(i128::MAX as u128),
+        &100_000u64,
     );
 
     // Maximum i128 amount should succeed if balance allows
@@ -416,6 +429,7 @@ fn test_contribution_exceeding_balance_fails() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Try to contribute more than balance - should fail with token transfer error
@@ -439,6 +453,7 @@ fn test_close_disbursed_pool_succeeds() {
         &String::from_str(&env, "Disbursed Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Set pool state to Disbursed
@@ -467,6 +482,7 @@ fn test_close_cancelled_pool_succeeds() {
         &String::from_str(&env, "Cancelled Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Set pool state to Cancelled
@@ -496,6 +512,7 @@ fn test_close_active_pool_fails() {
         &String::from_str(&env, "Active Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Pool is in Active state by default - should fail
@@ -518,6 +535,7 @@ fn test_close_paused_pool_fails() {
         &String::from_str(&env, "Paused Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Set pool state to Paused
@@ -543,6 +561,7 @@ fn test_close_completed_pool_fails() {
         &String::from_str(&env, "Completed Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Set pool state to Completed
@@ -568,6 +587,7 @@ fn test_close_already_closed_pool_fails() {
         &String::from_str(&env, "Closed Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Set pool state to Closed
@@ -592,6 +612,7 @@ fn test_closed_state_persists() {
         &String::from_str(&env, "Test Pool"),
         &String::from_str(&env, "Test"),
         &1_000_000_000u128,
+        &100_000u64,
     );
 
     // Set pool state to Disbursed


### PR DESCRIPTION
# PR: [Test + Time] Ledger clock bounds tests & application_deadline on Pool (`test/ledger-clock-bounds`)

## Summary

- Add deterministic, test-oriented timestamp helpers and validators to exercise ledger-clock edge cases precisely.
- Add an `application_deadline` ledger bound to the `Pool` storage schema and propagate the field through constructors, updaters, and accessors.
- Add and adjust unit tests to validate exact, `±1` timestamp behavior and related bounds logic.

## What I changed

### `lib.rs`

#### Added test helpers

- `current_timestamp() -> u64`
- `is_within_grace_period(deadline, grace_period_secs) -> bool`
- `validate_deadline(deadline) -> Result<(), &str>`
- `set_deadline(deadline) -> Result<(), &str>`

#### Extended `Pool`

Added:

```rust
application_deadline: u64
```

#### Updated `create_pool(...)`

- Added a new parameter:

```rust
application_deadline: u64
```

- Persists the deadline when creating pools.

#### Updated `create_pool_for_school(...)`

- Accepts `application_deadline`.
- Forwards the value to `create_pool(...)`.

#### Updated Pool mutation flows

All locations that construct or update a `Pool` now preserve and propagate `application_deadline`, including:

- `donate`
- `donate_with_token`
- `close_pool`
- Withdraw flows
- `set_pool_state`
- Other `Pool` reconstruction paths

#### Updated `get_pool(...)`

Previous return type:

```rust
(u32, Address, u128, u128, bool)
```

New return type:

```rust
(u32, Address, u128, u128, bool, u64)
```

The sixth element is `application_deadline`.

---

### `test_timestamp_edge_cases.rs`

Existing timestamp boundary tests were updated to use the deterministic helpers.

Covered scenarios include:

- Deadline exactly equal to current timestamp
- Deadline at `+1` second
- Deadline at `-1` second
- Overflow handling
- Far-future timestamps
- Related boundary conditions

No significant structural changes were made beyond integrating the helper functions.

## Commits / branch

### Branch

```text
test/ledger-clock-bounds
```

### Commits

```text
test: add timestamp edge-case helpers and tests for ledger clock bounds (#341)

feat(pool): add application_deadline to Pool and update create_pool API (#337)
```

### Author

```text
EDOHWARES
```

## Compatibility & migration notes

### API breaking changes

The following signatures changed:

#### `create_pool(...)`

Now requires an additional parameter:

```rust
application_deadline: u64
```

#### `create_pool_for_school(...)`

Now requires an additional parameter:

```rust
application_deadline: u64
```

#### `get_pool(...)`

Now returns a 6-tuple:

```rust
(u32, Address, u128, u128, bool, u64)
```

Any client code destructuring the previous 5-tuple will need to be updated.

### Storage schema change

The `Pool` storage layout now includes `application_deadline`.

Existing deployed contracts will not automatically contain this field.

This change is intended for:

- New deployments
- Explicit migrations

If migrating existing pools on-chain, consider assigning a sensible default value for `application_deadline`.

## Tests

Unit tests were added and updated to validate exact time-boundary behavior.

Deterministic helpers are used to avoid flaky tests caused by ledger-time dependencies.

## Testing & formatting

Run tests:

```bash
cargo test
```

Or use the project's preferred test runner.

Run formatting and linting as needed:

```bash
cargo fmt --all
cargo clippy -- -D warnings
```

## Notes / next steps

- Update external clients and integration tests that depend on the previous `create_pool` and `get_pool` signatures.
- Consider gating deterministic helper functions behind:

```rust
#[cfg(test)]
```

or moving them into dedicated test modules to avoid shipping test-only utilities in production builds.

Possible follow-ups:

- Re-run tests locally and resolve minor issues.
- Add a migration helper to backfill `application_deadline` for existing pools.

Closes #341 
Closes #337 