### PR TITLE
Feature/issue 683 horizon service

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Detect which packages have changes being pushed
-UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)
+UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || true)
 if [ -z "$UPSTREAM" ]; then
   CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null)
 else

--- a/nevo_server/package-lock.json
+++ b/nevo_server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
+        "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/platform-express": "^11.0.1",
@@ -2313,6 +2314,33 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "17.4.1",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.18.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nestjs/core": {
@@ -5062,6 +5090,21 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7662,7 +7705,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {

--- a/nevo_server/package.json
+++ b/nevo_server/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
@@ -72,6 +73,12 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^(\\.\\.?/.*)\\.js$": "$1"
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(@stellar/stellar-sdk|@noble/.*|uint8array-extras)/)"
+    ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/nevo_server/src/app.module.ts
+++ b/nevo_server/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller.js';
@@ -10,6 +11,7 @@ import { User } from './users/user.entity.js';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRoot({
       type: 'postgres',
       host: process.env.DB_HOST ?? 'localhost',

--- a/nevo_server/src/contract/contract.module.ts
+++ b/nevo_server/src/contract/contract.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ContractService } from './contract.service.js';
+import { HorizonService } from './horizon.service.js';
 
 @Module({
-  providers: [ContractService],
-  exports: [ContractService],
+  providers: [ContractService, HorizonService],
+  exports: [ContractService, HorizonService],
 })
 export class ContractModule {}

--- a/nevo_server/src/contract/contract.service.spec.ts
+++ b/nevo_server/src/contract/contract.service.spec.ts
@@ -1,9 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { TransactionBuilder, Networks } from '@stellar/stellar-sdk';
+import { TransactionBuilder, Networks, Keypair } from '@stellar/stellar-sdk';
 import { ContractService } from './contract.service.js';
 import { StellarError } from './stellar.error.js';
 
-const SOURCE = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+const SOURCE = Keypair.random().publicKey();
 const NETWORK = Networks.TESTNET;
 
 describe('ContractService', () => {
@@ -50,15 +50,13 @@ describe('ContractService', () => {
 
   describe('buildWithdrawTransaction', () => {
     it('returns a parseable XDR string', () => {
-      const tokenAddress =
-        'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+      const tokenAddress = Keypair.random().publicKey();
       const xdr = service.buildWithdrawTransaction(SOURCE, 1, tokenAddress);
       expect(() => TransactionBuilder.fromXDR(xdr, NETWORK)).not.toThrow();
     });
 
     it('XDR contains the token address bytes', () => {
-      const tokenAddress =
-        'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+      const tokenAddress = Keypair.random().publicKey();
       const xdr = service.buildWithdrawTransaction(SOURCE, 1, tokenAddress);
       expect(xdr.length).toBeGreaterThan(0);
     });

--- a/nevo_server/src/contract/contract.service.ts
+++ b/nevo_server/src/contract/contract.service.ts
@@ -8,6 +8,7 @@ import {
   xdr,
   nativeToScVal,
   Contract,
+  scValToNative,
 } from '@stellar/stellar-sdk';
 import { rpc as StellarRpc } from '@stellar/stellar-sdk';
 import { StellarError } from './stellar.error.js';
@@ -158,6 +159,118 @@ export class ContractService {
       return 0n;
     } catch {
       return 0n;
+    }
+  }
+
+  async getPoolOnChain(poolId: number): Promise<{
+    sponsor: string;
+    goal: bigint;
+    collected: bigint;
+    isClosed: boolean;
+    applicationDeadline: bigint;
+  } | null> {
+    try {
+      const server = new StellarRpc.Server(SOROBAN_URL);
+      const keypair = SOURCE_SECRET
+        ? Keypair.fromSecret(SOURCE_SECRET)
+        : Keypair.random();
+      const account = await server.getAccount(keypair.publicKey());
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      })
+        .addOperation(
+          this.contract.call(
+            'get_pool',
+            nativeToScVal(poolId, { type: 'u32' }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const result = await server.simulateTransaction(tx);
+      if ('error' in result) return null;
+
+      const retVal = result.result?.retval;
+      if (!retVal) return null;
+
+      const native = scValToNative(retVal);
+      if (Array.isArray(native) && native.length >= 6) {
+        return {
+          sponsor: String(native[1]),
+          goal: BigInt(native[2]),
+          collected: BigInt(native[3]),
+          isClosed: Boolean(native[4]),
+          applicationDeadline: BigInt(native[5]),
+        };
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getTotalRaisedOnChain(poolId: number): Promise<bigint> {
+    try {
+      const server = new StellarRpc.Server(SOROBAN_URL);
+      const keypair = SOURCE_SECRET
+        ? Keypair.fromSecret(SOURCE_SECRET)
+        : Keypair.random();
+      const account = await server.getAccount(keypair.publicKey());
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      })
+        .addOperation(
+          this.contract.call(
+            'get_total_raised',
+            nativeToScVal(poolId, { type: 'u32' }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const result = await server.simulateTransaction(tx);
+      if ('error' in result) return 0n;
+
+      const retVal = result.result?.retval;
+      if (!retVal) return 0n;
+
+      return BigInt(scValToNative(retVal));
+    } catch {
+      return 0n;
+    }
+  }
+
+  async getDonorCountOnChain(poolId: number): Promise<number> {
+    try {
+      const server = new StellarRpc.Server(SOROBAN_URL);
+      const keypair = SOURCE_SECRET
+        ? Keypair.fromSecret(SOURCE_SECRET)
+        : Keypair.random();
+      const account = await server.getAccount(keypair.publicKey());
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: NETWORK_PASSPHRASE,
+      })
+        .addOperation(
+          this.contract.call(
+            'get_donor_count',
+            nativeToScVal(poolId, { type: 'u32' }),
+          ),
+        )
+        .setTimeout(30)
+        .build();
+
+      const result = await server.simulateTransaction(tx);
+      if ('error' in result) return 0;
+
+      const retVal = result.result?.retval;
+      if (!retVal) return 0;
+
+      return Number(scValToNative(retVal));
+    } catch {
+      return 0;
     }
   }
 

--- a/nevo_server/src/contract/horizon.service.spec.ts
+++ b/nevo_server/src/contract/horizon.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { HorizonService } from './horizon.service.js';
+import { HttpException } from '@nestjs/common';
+
+describe('HorizonService', () => {
+  let service: HorizonService;
+  let mockConfigService: jest.Mocked<ConfigService>;
+  let originalFetch: typeof global.fetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(async () => {
+    mockConfigService = {
+      get: jest.fn().mockReturnValue('https://horizon-testnet.stellar.org'),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HorizonService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(HorizonService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getTransactions', () => {
+    it('should fetch transactions and return raw records', async () => {
+      const mockRecords = [{ id: 'tx_1' }, { id: 'tx_2' }];
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          _embedded: {
+            records: mockRecords,
+          },
+        }),
+      } as any;
+
+      global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+      const result = await service.getTransactions('contract_123');
+
+      expect(result).toEqual(mockRecords);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://horizon-testnet.stellar.org/accounts/contract_123/transactions?order=asc',
+      );
+    });
+
+    it('should support passing a cursor', async () => {
+      const mockRecords = [{ id: 'tx_1' }];
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          _embedded: {
+            records: mockRecords,
+          },
+        }),
+      } as any;
+
+      global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+      const result = await service.getTransactions('contract_123', 'cursor_xyz');
+
+      expect(result).toEqual(mockRecords);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://horizon-testnet.stellar.org/accounts/contract_123/transactions?order=asc&cursor=cursor_xyz',
+      );
+    });
+
+    it('should throw an HttpException if response is not ok', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+      } as any;
+
+      global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+      await expect(service.getTransactions('contract_123')).rejects.toThrow(
+        HttpException,
+      );
+    });
+  });
+});

--- a/nevo_server/src/contract/horizon.service.ts
+++ b/nevo_server/src/contract/horizon.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class HorizonService {
+  private readonly horizonUrl: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.horizonUrl = this.configService.get<string>(
+      'HORIZON_URL',
+      'https://horizon-testnet.stellar.org',
+    ).replace(/\/$/, '');
+  }
+
+  /**
+   * Fetches transactions for a specific contract/account ID from Horizon.
+   * @param contractId The contract or account ID to fetch transactions for.
+   * @param cursor The cursor to start fetching from (optional).
+   * @returns Raw Horizon transaction records.
+   */
+  async getTransactions(contractId: string, cursor?: string): Promise<any[]> {
+    try {
+      const url = new URL(`${this.horizonUrl}/accounts/${contractId}/transactions`);
+      url.searchParams.append('order', 'asc');
+      if (cursor) {
+        url.searchParams.append('cursor', cursor);
+      }
+
+      const response = await fetch(url.toString());
+      if (!response.ok) {
+        throw new HttpException(
+          `Failed to fetch transactions from Horizon: ${response.statusText}`,
+          response.status,
+        );
+      }
+
+      const data = (await response.json()) as any;
+      return data?._embedded?.records ?? [];
+    } catch (error: any) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        error.message || 'Internal server error while fetching transactions',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/nevo_server/src/pools/pools.controller.ts
+++ b/nevo_server/src/pools/pools.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   ForbiddenException,
+  Get,
   NotFoundException,
   Param,
   Patch,
@@ -31,6 +32,13 @@ export interface WithdrawDto {
 @Controller('pools')
 export class PoolsController {
   constructor(private readonly poolsService: PoolsService) {}
+
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    const pool = await this.poolsService.findOneMerged(id);
+    if (!pool) throw new NotFoundException('Pool not found');
+    return pool;
+  }
 
   @Post()
   create(@Body() dto: CreatePoolDto) {

--- a/nevo_server/src/pools/pools.module.ts
+++ b/nevo_server/src/pools/pools.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Pool } from './pool.entity';
 import { PoolsService } from './pools.service';
 import { PoolsController } from './pools.controller';
+import { ContractModule } from '../contract/contract.module.js';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Pool])],
+  imports: [TypeOrmModule.forFeature([Pool]), ContractModule],
   providers: [PoolsService],
   controllers: [PoolsController],
   exports: [PoolsService],

--- a/nevo_server/src/pools/pools.service.spec.ts
+++ b/nevo_server/src/pools/pools.service.spec.ts
@@ -2,10 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { PoolsService, ChainPoolData } from './pools.service';
 import { Pool } from './pool.entity';
+import { ContractService } from '../contract/contract.service.js';
 
 describe('PoolsService', () => {
   const chainData: ChainPoolData = {
-    contractPoolId: 'pool-1',
+    contractPoolId: '1',
     creatorWallet: 'GWALLET',
     goal: '10000',
   };
@@ -21,7 +22,7 @@ describe('PoolsService', () => {
   it('updates chain fields without overwriting off-chain metadata', async () => {
     const existing: Pool = {
       id: 'uuid-1',
-      contractPoolId: 'pool-1',
+      contractPoolId: '1',
       creatorWallet: 'GOLD',
       goal: '5000',
       title: 'Existing Title',
@@ -41,6 +42,73 @@ describe('PoolsService', () => {
     expect(saved.description).toBe('Existing description');
     expect(saved.imageUrl).toBe('https://example.com/img.png');
   });
+
+  describe('findOneMerged', () => {
+    it('returns null if the pool is not found in the DB', async () => {
+      const { service } = await buildService(null);
+      const result = await service.findOneMerged('1');
+      expect(result).toBeNull();
+    });
+
+    it('returns merged data if the pool is found and contract service returns data', async () => {
+      const existing: Pool = {
+        id: 'uuid-1',
+        contractPoolId: '1',
+        creatorWallet: 'GOLD',
+        goal: '5000',
+        title: 'Existing Title',
+        description: 'Existing description',
+        imageUrl: 'https://example.com/img.png',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const { service, contractService } = await buildService(existing);
+      
+      contractService.getPoolOnChain.mockResolvedValue({
+        sponsor: 'GOLD',
+        goal: 5000n,
+        collected: 2500n,
+        isClosed: true,
+        applicationDeadline: 1735689600n,
+      });
+      contractService.getDonorCountOnChain.mockResolvedValue(10);
+
+      const result = await service.findOneMerged('1');
+      expect(result).toEqual({
+        ...existing,
+        raisedOnChain: '2500',
+        closedOnChain: true,
+        donorCount: 10,
+      });
+    });
+
+    it('falls back gracefully to DB raised value if getPoolOnChain returns null but total raised returns value', async () => {
+      const existing: Pool = {
+        id: 'uuid-1',
+        contractPoolId: '1',
+        creatorWallet: 'GOLD',
+        goal: '5000',
+        title: 'Existing Title',
+        description: 'Existing description',
+        imageUrl: 'https://example.com/img.png',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const { service, contractService } = await buildService(existing);
+
+      contractService.getPoolOnChain.mockResolvedValue(null);
+      contractService.getTotalRaisedOnChain.mockResolvedValue(1500n);
+      contractService.getDonorCountOnChain.mockResolvedValue(5);
+
+      const result = await service.findOneMerged('1');
+      expect(result).toEqual({
+        ...existing,
+        raisedOnChain: '1500',
+        closedOnChain: false,
+        donorCount: 5,
+      });
+    });
+  });
 });
 
 async function buildService(existing: Pool | null) {
@@ -57,15 +125,23 @@ async function buildService(existing: Pool | null) {
       .mockImplementation((d: Partial<Pool>) => ({ ...d }) as Pool),
   };
 
+  const mockContractService = {
+    getPoolOnChain: jest.fn().mockResolvedValue(null),
+    getTotalRaisedOnChain: jest.fn().mockResolvedValue(0n),
+    getDonorCountOnChain: jest.fn().mockResolvedValue(0),
+  };
+
   const module: TestingModule = await Test.createTestingModule({
     providers: [
       PoolsService,
       { provide: getRepositoryToken(Pool), useValue: repo },
+      { provide: ContractService, useValue: mockContractService },
     ],
   }).compile();
 
   return {
     service: module.get(PoolsService),
+    contractService: mockContractService,
     savedArg: () => lastSaved as Pool,
   };
 }

--- a/nevo_server/src/pools/pools.service.ts
+++ b/nevo_server/src/pools/pools.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Pool } from './pool.entity';
 import type { CreatePoolDto, UpdatePoolDto } from './pools.controller';
+import { ContractService } from '../contract/contract.service.js';
 
 export interface ChainPoolData {
   contractPoolId: string;
@@ -15,6 +16,7 @@ export class PoolsService {
   constructor(
     @InjectRepository(Pool)
     private readonly poolRepo: Repository<Pool>,
+    private readonly contractService: ContractService,
   ) {}
 
   async upsertFromChain(data: ChainPoolData): Promise<Pool> {
@@ -63,6 +65,42 @@ export class PoolsService {
 
   async findByContractId(contractPoolId: string): Promise<Pool | null> {
     return this.poolRepo.findOne({ where: { contractPoolId } });
+  }
+
+  async findOneMerged(contractPoolId: string) {
+    const pool = await this.poolRepo.findOne({ where: { contractPoolId } });
+    if (!pool) return null;
+
+    const poolIdNum = parseInt(contractPoolId, 10);
+    let raisedOnChain = '0';
+    let closedOnChain = false;
+    let donorCount = 0;
+
+    if (!isNaN(poolIdNum)) {
+      const [poolOnChain, totalRaisedOnChain, donorCountOnChain] = await Promise.all([
+        this.contractService.getPoolOnChain(poolIdNum),
+        this.contractService.getTotalRaisedOnChain(poolIdNum),
+        this.contractService.getDonorCountOnChain(poolIdNum),
+      ]);
+
+      if (poolOnChain) {
+        raisedOnChain = poolOnChain.collected.toString();
+        closedOnChain = poolOnChain.isClosed;
+      } else if (totalRaisedOnChain) {
+        raisedOnChain = totalRaisedOnChain.toString();
+      }
+
+      if (donorCountOnChain) {
+        donorCount = donorCountOnChain;
+      }
+    }
+
+    return {
+      ...pool,
+      raisedOnChain,
+      closedOnChain,
+      donorCount,
+    };
   }
 
   buildWithdrawTx(pool: Pool): { unsignedXdr: string; poolId: string } {


### PR DESCRIPTION
# Pull Request: Implement HorizonService (#683) and GET /pools/:id Merged Endpoint (#654)

## Description
This PR delivers the implementation of both **HorizonService** (polling transactions/events from Horizon) and the **GET /pools/:id** endpoint, which successfully aggregates off-chain database metadata with live, on-chain contract state.

---

## Deliverables & Key Changes

### 1. Horizon Service (#683)
* **New Service:** Created `src/contract/horizon.service.ts`.
  * Dynamically reads `HORIZON_URL` from the configuration via `ConfigService` (defaulting to the Stellar Testnet Horizon URL).
  * Exposes `getTransactions(contractId, cursor?)` fetching transactions from the Horizon API.
* **Global Configuration:** Registered `ConfigModule` globally inside `AppModule`.
* **Testing:** Added robust unit test coverage in `src/contract/horizon.service.spec.ts`.

### 2. Merged Pool Endpoint (#654)
* **On-Chain Readers:** Extended `ContractService` with methods to simulate reads:
  * `getPoolOnChain(poolId)`
  * `getTotalRaisedOnChain(poolId)`
  * `getDonorCountOnChain(poolId)`
  * Used `@stellar/stellar-sdk`'s `scValToNative` to easily decode Soroban vector/primitive results back to native JavaScript data types.
* **GET `/pools/:id` Endpoint:**
  * Looks up the pool metadata by `contractPoolId` in the database (returning `404` if not found).
  * Concurrently fetches live contract data (`collected`, `isClosed`, and `donorCount`) and merges it into the response.
  * Extends response payload with: all DB fields + `raisedOnChain`, `closedOnChain`, and `donorCount`.
* **Module Dependency:** Imported `ContractModule` into `PoolsModule` to enable injecting `ContractService`.
* **Testing:**
  * Added unit tests in `pools.service.spec.ts` validating successful merging, 404 responses, and graceful fallbacks.

### 3. Stability & Testing Improvements
* **Fixed Pre-Existing Test Failures:**
  * Resolved the ESM dependency compilation issues for Jest (configured `transformIgnorePatterns` for `@noble/.*`, `@stellar/stellar-sdk`, and `uint8array-extras`).
  * Replaced the invalid 55-character hardcoded source address in `contract.service.spec.ts` with dynamically generated keys using `Keypair.random()`.
* **DevOps Hook Fix:**
  * Updated `.husky/pre-push` to append `|| true` to the `git rev-parse` upstream check. This prevents push failures (Exit Code 128) on newly created local branches that don't have an upstream tracked branch configured yet.

---

## Validation Checklist

- [x] Backend tests pass successfully (`npm run test` from `nevo_server/` executes all 21 tests green)
- [x] NestJS application compiles cleanly (`npm run build` has no errors)
- [x] Changes conform to the single-layer scope rule (only backend `nevo_server/` + local development git hooks modified)

Closes #683 
Closes #654 