### PR TITLE
feat: resolve issues #573, #577, #579, #688

### DIFF
--- a/nevo_frontend/app/help/page.tsx
+++ b/nevo_frontend/app/help/page.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import React, { useState, useId } from 'react';
+import Link from 'next/link';
+
+interface FaqItem {
+  id: string;
+  question: string;
+  answer: string;
+  category: string;
+}
+
+const FAQ_ITEMS: FaqItem[] = [
+  {
+    id: 'what-is-nevo',
+    category: 'General',
+    question: 'What is Nevo?',
+    answer:
+      'Nevo is an open-source on-chain donation platform built on the Stellar blockchain. It lets anyone create transparent fundraising pools where every contribution is recorded on-chain and withdrawals are handled by a smart contract — no intermediaries.',
+  },
+  {
+    id: 'how-transparent',
+    category: 'General',
+    question: 'How is Nevo transparent?',
+    answer:
+      'Every donation and withdrawal is recorded directly on the Stellar blockchain. Anyone can verify transactions using a blockchain explorer like Stellar Expert. No funds can be moved without a smart contract interaction, ensuring full auditability.',
+  },
+  {
+    id: 'supported-wallets',
+    category: 'General',
+    question: 'Which wallets are supported?',
+    answer:
+      'Nevo supports Freighter wallet and other Stellar-compatible wallets via the Stellar Wallets Kit. We recommend Freighter for the best experience. Make sure your wallet is set to the correct Stellar network.',
+  },
+  {
+    id: 'create-pool',
+    category: 'Creating Pools',
+    question: 'How do I create a donation pool?',
+    answer:
+      'Connect your Stellar wallet, then navigate to Pools → Create Pool. Fill in your pool title, description, goal amount, and category. Once submitted, a smart contract transaction will be created and you will need to sign it in your wallet. After confirmation the pool goes live on-chain.',
+  },
+  {
+    id: 'pool-fees',
+    category: 'Creating Pools',
+    question: 'Are there fees for creating a pool?',
+    answer:
+      'Nevo itself charges no platform fees. You only pay the standard Stellar network fee (typically under $0.01 USD) to submit the smart contract transaction. The pool funds belong entirely to the creator and donors.',
+  },
+  {
+    id: 'edit-pool',
+    category: 'Creating Pools',
+    question: 'Can I edit my pool after creating it?',
+    answer:
+      'Off-chain metadata such as description and images can be updated by the pool creator from the pool detail page. The goal amount and creator wallet are recorded on-chain at creation and cannot be changed afterwards.',
+  },
+  {
+    id: 'how-to-donate',
+    category: 'Donating',
+    question: 'How do I donate to a pool?',
+    answer:
+      'Browse or search for a pool on the Pools page, then open its detail page. Click "Donate Now", enter the amount you want to contribute, and confirm the transaction in your Stellar wallet. Your donation is recorded on-chain instantly.',
+  },
+  {
+    id: 'minimum-donation',
+    category: 'Donating',
+    question: 'Is there a minimum donation amount?',
+    answer:
+      'The minimum donation is determined by the smart contract. In most cases any amount above the Stellar network dust threshold (0.0000001 XLM) is accepted. There is no platform-imposed minimum.',
+  },
+  {
+    id: 'refund-donation',
+    category: 'Donating',
+    question: 'Can I get a refund on my donation?',
+    answer:
+      'Blockchain transactions are irreversible by design. Once your donation is confirmed on the Stellar network it cannot be reversed. Please verify the pool details carefully before donating.',
+  },
+  {
+    id: 'withdraw-funds',
+    category: 'Withdrawals',
+    question: 'How does a pool creator withdraw funds?',
+    answer:
+      'Pool creators can withdraw raised funds from the pool detail page once the pool is active and has reached its goal or is ready to close. The smart contract will generate an unsigned transaction that the creator must sign in their wallet.',
+  },
+  {
+    id: 'who-can-withdraw',
+    category: 'Withdrawals',
+    question: 'Who is allowed to withdraw from a pool?',
+    answer:
+      'Only the wallet address that created the pool (the pool creator) is authorised to withdraw funds. This is enforced at the smart contract level — no other address can move the funds.',
+  },
+  {
+    id: 'view-transaction',
+    category: 'Blockchain',
+    question: 'How do I view my transaction on the blockchain?',
+    answer:
+      'Go to the Transaction History page (Transactions in the nav). Each transaction row shows a truncated hash and an "Explorer" link that opens the full transaction on Stellar Expert in a new tab, where you can see all on-chain details including fees and status.',
+  },
+  {
+    id: 'network-fees',
+    category: 'Blockchain',
+    question: 'What network fees apply?',
+    answer:
+      'Stellar network fees are very low — typically around 100 stroops (0.00001 XLM) per operation, which is a fraction of a cent. Smart contract invocations may incur slightly higher fees depending on resource usage, but they remain well under $0.01 USD.',
+  },
+  {
+    id: 'testnet-mainnet',
+    category: 'Blockchain',
+    question: 'Is Nevo on testnet or mainnet?',
+    answer:
+      'Nevo is currently running on the Stellar testnet. Testnet XLM has no real value and is used for testing purposes. We will announce the mainnet launch separately. Make sure your Freighter wallet is pointed at the correct network.',
+  },
+];
+
+const CATEGORIES = Array.from(new Set(FAQ_ITEMS.map((item) => item.category)));
+
+function ChevronDownIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className={`size-4 flex-shrink-0 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="size-4"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+      />
+    </svg>
+  );
+}
+
+interface AccordionItemProps {
+  item: FaqItem;
+  open: boolean;
+  onToggle: () => void;
+}
+
+function AccordionItem({ item, open, onToggle }: AccordionItemProps) {
+  const panelId = useId();
+  const headingId = useId();
+
+  return (
+    <div className="border-b border-[var(--color-border)] last:border-b-0">
+      <h3>
+        <button
+          type="button"
+          id={headingId}
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={onToggle}
+          className="flex w-full items-center justify-between gap-4 py-4 text-left text-sm font-medium text-[var(--color-text)] hover:text-brand-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 transition-colors"
+        >
+          <span>{item.question}</span>
+          <ChevronDownIcon open={open} />
+        </button>
+      </h3>
+      <div
+        id={panelId}
+        role="region"
+        aria-labelledby={headingId}
+        hidden={!open}
+      >
+        <p className="pb-4 text-sm leading-relaxed text-[var(--color-text-muted)]">
+          {item.answer}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function HelpPage() {
+  const searchId = useId();
+  const [search, setSearch] = useState('');
+  const [activeCategory, setActiveCategory] = useState<string>('All');
+  const [openItems, setOpenItems] = useState<Set<string>>(new Set());
+
+  const normalizedSearch = search.trim().toLowerCase();
+
+  const filteredItems = FAQ_ITEMS.filter((item) => {
+    const matchesCategory =
+      activeCategory === 'All' || item.category === activeCategory;
+    const matchesSearch =
+      !normalizedSearch ||
+      item.question.toLowerCase().includes(normalizedSearch) ||
+      item.answer.toLowerCase().includes(normalizedSearch);
+    return matchesCategory && matchesSearch;
+  });
+
+  const groupedItems = CATEGORIES.reduce<Record<string, FaqItem[]>>(
+    (acc, category) => {
+      const items = filteredItems.filter((item) => item.category === category);
+      if (items.length > 0) acc[category] = items;
+      return acc;
+    },
+    {}
+  );
+
+  function toggleItem(id: string) {
+    setOpenItems((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  const hasResults = filteredItems.length > 0;
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-10 sm:px-6 sm:py-16">
+      <div className="mb-10 text-center">
+        <h1 className="text-3xl font-bold tracking-tight">Help &amp; FAQ</h1>
+        <p className="mt-3 text-[var(--color-text-muted)]">
+          Answers to common questions about creating pools, donating, and using
+          the platform.
+        </p>
+      </div>
+
+      {/* Search */}
+      <div className="relative mb-6">
+        <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-[var(--color-text-muted)]">
+          <SearchIcon />
+        </span>
+        <label htmlFor={searchId} className="sr-only">
+          Search FAQ
+        </label>
+        <input
+          id={searchId}
+          type="search"
+          placeholder="Search questions…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] py-3 pl-10 pr-4 text-sm placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-brand-500"
+        />
+      </div>
+
+      {/* Category tabs */}
+      <div
+        role="tablist"
+        aria-label="FAQ categories"
+        className="mb-8 flex flex-wrap gap-2"
+      >
+        {['All', ...CATEGORIES].map((category) => (
+          <button
+            key={category}
+            role="tab"
+            type="button"
+            aria-selected={activeCategory === category}
+            onClick={() => setActiveCategory(category)}
+            className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 ${
+              activeCategory === category
+                ? 'bg-brand-600 text-white'
+                : 'border border-[var(--color-border)] text-[var(--color-text-muted)] hover:border-brand-400 hover:text-brand-600'
+            }`}
+          >
+            {category}
+          </button>
+        ))}
+      </div>
+
+      {/* FAQ accordion */}
+      {hasResults ? (
+        <div className="flex flex-col gap-8">
+          {Object.entries(groupedItems).map(([category, items]) => (
+            <section key={category} aria-labelledby={`cat-${category}`}>
+              <h2
+                id={`cat-${category}`}
+                className="mb-3 text-xs font-bold uppercase tracking-wider text-[var(--color-text-muted)]"
+              >
+                {category}
+              </h2>
+              <div className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] px-5">
+                {items.map((item) => (
+                  <AccordionItem
+                    key={item.id}
+                    item={item}
+                    open={openItems.has(item.id)}
+                    onToggle={() => toggleItem(item.id)}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-dashed border-[var(--color-border)] bg-[var(--color-surface-raised)] px-6 py-12 text-center">
+          <p className="font-semibold text-[var(--color-text)]">
+            No results found
+          </p>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            Try a different search term or browse all categories.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              setSearch('');
+              setActiveCategory('All');
+            }}
+            className="mt-4 rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white hover:bg-brand-700 transition-colors"
+          >
+            Clear search
+          </button>
+        </div>
+      )}
+
+      {/* Contact support */}
+      <div className="mt-12 rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface-raised)] p-6 text-center">
+        <p className="font-semibold">Still have questions?</p>
+        <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+          Can&apos;t find what you&apos;re looking for? Reach out and we&apos;ll
+          help.
+        </p>
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <a
+            href="mailto:hello@nevo.app"
+            className="inline-flex items-center justify-center rounded-xl bg-brand-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-brand-700 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+          >
+            Email Support
+          </a>
+          <Link
+            href="/about"
+            className="inline-flex items-center justify-center rounded-xl border border-[var(--color-border)] px-5 py-2.5 text-sm font-semibold hover:bg-[var(--color-surface)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+          >
+            About Nevo
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/nevo_frontend/app/pools/[id]/page.tsx
+++ b/nevo_frontend/app/pools/[id]/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import React, { useEffect, useId, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
 import { DonateModal } from '@/components/DonateModal';
 import { EmptyState } from '@/components/EmptyState';
 import { WalletAddress } from '@/components/WalletAddress';
@@ -55,6 +55,53 @@ interface TimelineEvent {
   amount?: number;
 }
 
+// ── Comments ────────────────────────────────────────────────────────────────
+
+interface Comment {
+  id: string;
+  poolId: string;
+  authorAddress: string;
+  text: string;
+  createdAt: string;
+  updatedAt?: string;
+  parentId: string | null;
+  replies: Comment[];
+}
+
+// TODO: Replace with real API call to GET /pools/:id/comments
+const MOCK_COMMENTS: Record<string, Comment[]> = {
+  '1': [
+    {
+      id: 'c1',
+      poolId: '1',
+      authorAddress: 'GXYZ1234567890ABCDE1234567890ABCDE1234567890ABCDE1234567890AB',
+      text: 'Amazing initiative! How are the funds being allocated?',
+      createdAt: '2025-03-06T10:00:00Z',
+      parentId: null,
+      replies: [
+        {
+          id: 'c1r1',
+          poolId: '1',
+          authorAddress: 'GABC9876543210ZYXWV9876543210ZYXWV9876543210ZYXWV9876543210ZY',
+          text: 'Funds go directly to vetted local partners. You can track every withdrawal on-chain!',
+          createdAt: '2025-03-06T11:30:00Z',
+          parentId: 'c1',
+          replies: [],
+        },
+      ],
+    },
+    {
+      id: 'c2',
+      poolId: '1',
+      authorAddress: 'GABC9876543210ZYXWV9876543210ZYXWV9876543210ZYXWV9876543210ZY',
+      text: 'Love that everything is transparent on-chain. Keep up the great work!',
+      createdAt: '2025-03-10T14:20:00Z',
+      parentId: null,
+      replies: [],
+    },
+  ],
+};
+
 const MOCK_LAST_UPDATED: Record<string, string> = {
   '1': '2025-04-15',
   '2': '2025-02-01',
@@ -71,6 +118,7 @@ export default function PoolDetailPage() {
     fetchPool,
   } = usePoolsStore();
   const [contributors, setContributors] = useState<Contributor[]>([]);
+  const [comments, setComments] = useState<Comment[]>([]);
   const [donateOpen, setDonateOpen] = useState(false);
 
   useEffect(() => {
@@ -85,6 +133,8 @@ export default function PoolDetailPage() {
         router.replace('/pools');
       } else {
         setContributors(MOCK_CONTRIBUTORS[id] ?? []);
+        // TODO: replace with real API call: apiClient.get(`/pools/${id}/comments`)
+        setComments(MOCK_COMMENTS[id] ?? []);
       }
     };
     loadPool();
@@ -276,6 +326,21 @@ export default function PoolDetailPage() {
             )}
           </section>
 
+          <section aria-labelledby="comments-heading">
+            <h2 id="comments-heading" className="mb-4 text-lg font-semibold">
+              Discussion
+              <span className="ml-2 text-sm font-normal text-[var(--color-text-muted)]">
+                ({comments.reduce((sum, c) => sum + 1 + c.replies.length, 0)})
+              </span>
+            </h2>
+            <CommentsSection
+              poolId={id}
+              comments={comments}
+              setComments={setComments}
+              currentUserAddress={publicKey}
+            />
+          </section>
+
           <section aria-labelledby="timeline-heading">
             <h2 id="timeline-heading" className="mb-4 text-lg font-semibold">
               History
@@ -444,6 +509,354 @@ function PoolDetailSkeleton() {
         <div className="h-64 w-full animate-pulse rounded-2xl bg-[var(--color-border)]" />
       </div>
     </main>
+  );
+}
+
+// ── CommentsSection ──────────────────────────────────────────────────────────
+
+interface CommentsSectionProps {
+  poolId: string;
+  comments: Comment[];
+  setComments: React.Dispatch<React.SetStateAction<Comment[]>>;
+  currentUserAddress: string | null;
+}
+
+function CommentsSection({
+  poolId,
+  comments,
+  setComments,
+  currentUserAddress,
+}: CommentsSectionProps) {
+  function handleAddComment(text: string) {
+    if (!currentUserAddress) return;
+    const newComment: Comment = {
+      id: `c-${Date.now()}`,
+      poolId,
+      authorAddress: currentUserAddress,
+      text,
+      createdAt: new Date().toISOString(),
+      parentId: null,
+      replies: [],
+    };
+    // TODO: replace with real API call: apiClient.post(`/pools/${poolId}/comments`, { text })
+    setComments((prev) => [newComment, ...prev]);
+  }
+
+  function handleAddReply(parentId: string, text: string) {
+    if (!currentUserAddress) return;
+    const newReply: Comment = {
+      id: `c-${Date.now()}`,
+      poolId,
+      authorAddress: currentUserAddress,
+      text,
+      createdAt: new Date().toISOString(),
+      parentId,
+      replies: [],
+    };
+    // TODO: replace with real API call: apiClient.post(`/pools/${poolId}/comments`, { text, parentId })
+    setComments((prev) =>
+      prev.map((c) =>
+        c.id === parentId ? { ...c, replies: [...c.replies, newReply] } : c
+      )
+    );
+  }
+
+  function handleEditComment(id: string, text: string, isReply: boolean, parentId?: string) {
+    // TODO: replace with real API call: apiClient.put(`/pools/${poolId}/comments/${id}`, { text })
+    if (isReply && parentId) {
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === parentId
+            ? {
+                ...c,
+                replies: c.replies.map((r) =>
+                  r.id === id ? { ...r, text, updatedAt: new Date().toISOString() } : r
+                ),
+              }
+            : c
+        )
+      );
+    } else {
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === id ? { ...c, text, updatedAt: new Date().toISOString() } : c
+        )
+      );
+    }
+  }
+
+  function handleDeleteComment(id: string, isReply: boolean, parentId?: string) {
+    // TODO: replace with real API call: apiClient.delete(`/pools/${poolId}/comments/${id}`)
+    if (isReply && parentId) {
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === parentId
+            ? { ...c, replies: c.replies.filter((r) => r.id !== id) }
+            : c
+        )
+      );
+    } else {
+      setComments((prev) => prev.filter((c) => c.id !== id));
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <CommentForm
+        onSubmit={handleAddComment}
+        currentUserAddress={currentUserAddress}
+        placeholder="Share a thought or ask a question…"
+      />
+
+      {comments.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-8 text-center">
+          <p className="font-semibold">No comments yet</p>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            Be the first to start the discussion.
+          </p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-4" role="list">
+          {comments.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              currentUserAddress={currentUserAddress}
+              onReply={(text) => handleAddReply(comment.id, text)}
+              onEdit={(text) => handleEditComment(comment.id, text, false)}
+              onDelete={() => handleDeleteComment(comment.id, false)}
+              onEditReply={(replyId, text) =>
+                handleEditComment(replyId, text, true, comment.id)
+              }
+              onDeleteReply={(replyId) =>
+                handleDeleteComment(replyId, true, comment.id)
+              }
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── CommentForm ──────────────────────────────────────────────────────────────
+
+interface CommentFormProps {
+  onSubmit: (text: string) => void;
+  currentUserAddress: string | null;
+  placeholder?: string;
+  initialValue?: string;
+  onCancel?: () => void;
+  submitLabel?: string;
+}
+
+function CommentForm({
+  onSubmit,
+  currentUserAddress,
+  placeholder = 'Write a comment…',
+  initialValue = '',
+  onCancel,
+  submitLabel = 'Post',
+}: CommentFormProps) {
+  const [text, setText] = useState(initialValue);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setText('');
+  }
+
+  if (!currentUserAddress) {
+    return (
+      <p className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
+        Connect your wallet to join the discussion.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <label className="sr-only" htmlFor="comment-input">
+        {placeholder}
+      </label>
+      <textarea
+        id="comment-input"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={placeholder}
+        rows={3}
+        className="w-full resize-none rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm placeholder:text-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-brand-500"
+        aria-label={placeholder}
+      />
+      <div className="flex items-center justify-end gap-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium hover:bg-[var(--color-surface-raised)] transition-colors"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="submit"
+          disabled={!text.trim()}
+          className="rounded-full bg-brand-600 px-4 py-1.5 text-xs font-semibold text-white hover:bg-brand-700 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── CommentItem ───────────────────────────────────────────────────────────────
+
+interface CommentItemProps {
+  comment: Comment;
+  currentUserAddress: string | null;
+  onReply: (text: string) => void;
+  onEdit: (text: string) => void;
+  onDelete: () => void;
+  onEditReply: (replyId: string, text: string) => void;
+  onDeleteReply: (replyId: string) => void;
+  isReply?: boolean;
+}
+
+function formatCommentDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function CommentItem({
+  comment,
+  currentUserAddress,
+  onReply,
+  onEdit,
+  onDelete,
+  onEditReply,
+  onDeleteReply,
+  isReply = false,
+}: CommentItemProps) {
+  const [showReplyForm, setShowReplyForm] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const isOwn = currentUserAddress !== null && currentUserAddress === comment.authorAddress;
+  const shortAddress = `${comment.authorAddress.slice(0, 6)}…${comment.authorAddress.slice(-4)}`;
+
+  return (
+    <li
+      className={`rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4 ${isReply ? 'ml-6 border-l-2 border-l-brand-200' : ''}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <span
+            className="font-mono text-xs font-medium text-brand-600"
+            title={comment.authorAddress}
+          >
+            {shortAddress}
+          </span>
+          <time
+            dateTime={comment.createdAt}
+            className="text-xs text-[var(--color-text-muted)]"
+          >
+            {formatCommentDate(comment.createdAt)}
+            {comment.updatedAt && (
+              <span className="ml-1 italic">(edited)</span>
+            )}
+          </time>
+        </div>
+        {isOwn && (
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              className="text-xs text-[var(--color-text-muted)] hover:text-brand-600 transition-colors"
+              aria-label="Edit comment"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={onDelete}
+              className="text-xs text-[var(--color-text-muted)] hover:text-red-600 transition-colors"
+              aria-label="Delete comment"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+
+      {isEditing ? (
+        <div className="mt-2">
+          <CommentForm
+            onSubmit={(text) => {
+              onEdit(text);
+              setIsEditing(false);
+            }}
+            currentUserAddress={currentUserAddress}
+            placeholder="Edit your comment…"
+            initialValue={comment.text}
+            onCancel={() => setIsEditing(false)}
+            submitLabel="Save"
+          />
+        </div>
+      ) : (
+        <p className="mt-2 text-sm text-[var(--color-text)]">{comment.text}</p>
+      )}
+
+      {!isReply && (
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => setShowReplyForm((v) => !v)}
+            className="text-xs text-[var(--color-text-muted)] hover:text-brand-600 transition-colors"
+          >
+            {showReplyForm ? 'Cancel reply' : `Reply${comment.replies.length > 0 ? ` (${comment.replies.length})` : ''}`}
+          </button>
+
+          {showReplyForm && (
+            <div className="mt-3">
+              <CommentForm
+                onSubmit={(text) => {
+                  onReply(text);
+                  setShowReplyForm(false);
+                }}
+                currentUserAddress={currentUserAddress}
+                placeholder="Write a reply…"
+                onCancel={() => setShowReplyForm(false)}
+                submitLabel="Reply"
+              />
+            </div>
+          )}
+
+          {comment.replies.length > 0 && (
+            <ul className="mt-3 flex flex-col gap-3" role="list">
+              {comment.replies.map((reply) => (
+                <CommentItem
+                  key={reply.id}
+                  comment={reply}
+                  currentUserAddress={currentUserAddress}
+                  onReply={() => {}}
+                  onEdit={(text) => onEditReply(reply.id, text)}
+                  onDelete={() => onDeleteReply(reply.id)}
+                  onEditReply={() => {}}
+                  onDeleteReply={() => {}}
+                  isReply
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </li>
   );
 }
 

--- a/nevo_frontend/app/transactions/page.tsx
+++ b/nevo_frontend/app/transactions/page.tsx
@@ -516,7 +516,31 @@ function TransactionsPageContent() {
 
 import { CopyButton } from '@/components/CopyButton';
 
+const STELLAR_EXPERT_BASE = 'https://stellar.expert/explorer/testnet/tx';
+
+function ExternalLinkIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="size-3"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+      />
+    </svg>
+  );
+}
+
 function TransactionRow({ tx }: { tx: Transaction }) {
+  const explorerUrl = `${STELLAR_EXPERT_BASE}/${tx.txHash}`;
+
   return (
     <li className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4 transition-shadow hover:shadow-sm">
       <div className="flex items-start gap-4">
@@ -552,7 +576,7 @@ function TransactionRow({ tx }: { tx: Transaction }) {
             <time dateTime={tx.date}>
               {formatDate(tx.date)} · {formatTime(tx.date)}
             </time>
-            <span className="inline-flex items-center gap-1">
+            <span className="inline-flex items-center gap-1.5">
               <span className="font-mono truncate max-w-32" title={tx.txHash}>
                 {tx.txHash.slice(0, 8)}…
               </span>
@@ -561,6 +585,16 @@ function TransactionRow({ tx }: { tx: Transaction }) {
                 iconOnly
                 aria-label={`Copy transaction hash ${tx.txHash}`}
               />
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-0.5 text-brand-600 hover:text-brand-700 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-brand-600 rounded"
+                aria-label={`View transaction ${tx.txHash.slice(0, 8)} on Stellar Expert blockchain explorer (opens in new tab)`}
+              >
+                Explorer
+                <ExternalLinkIcon />
+              </a>
             </span>
           </div>
         </div>

--- a/nevo_server/src/pools/pools.service.spec.ts
+++ b/nevo_server/src/pools/pools.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { PoolsService, ChainPoolData } from './pools.service';
+import { Pool, PoolStatus } from './pool.entity';
+import { ContractService } from '../contract/contract.service';
 
 describe('PoolsService', () => {
   const chainData: ChainPoolData = {
@@ -108,6 +110,36 @@ describe('PoolsService', () => {
         closedOnChain: false,
         donorCount: 5,
       });
+    });
+  });
+
+  describe('markCompleted', () => {
+    it('sets pool status to Completed and saves', async () => {
+      const existing: Pool = {
+        id: 'uuid-1',
+        contractPoolId: 'pool-1',
+        creatorWallet: 'GWALLET',
+        goal: '5000',
+        raised: '0',
+        status: PoolStatus.Active,
+        category: '',
+        title: 'My Pool',
+        description: '',
+        imageUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const { service, savedArg } = await buildService(existing);
+
+      await service.markCompleted('pool-1');
+
+      expect(savedArg().status).toBe(PoolStatus.Completed);
+    });
+
+    it('returns null if pool is not found', async () => {
+      const { service } = await buildService(null);
+      const result = await service.markCompleted('nonexistent');
+      expect(result).toBeNull();
     });
   });
 });

--- a/nevo_server/src/pools/pools.service.ts
+++ b/nevo_server/src/pools/pools.service.ts
@@ -111,6 +111,13 @@ export class PoolsService {
     };
   }
 
+  async markCompleted(contractPoolId: string): Promise<Pool | null> {
+    const pool = await this.poolRepo.findOne({ where: { contractPoolId } });
+    if (!pool) return null;
+    pool.status = PoolStatus.Completed;
+    return this.poolRepo.save(pool);
+  }
+
   buildWithdrawTx(pool: Pool): { unsignedXdr: string; poolId: string } {
     // TODO: replace with real Stellar transaction build calling contract.withdraw (#657)
     return { unsignedXdr: 'placeholder_xdr', poolId: pool.contractPoolId };

--- a/nevo_server/src/sync/sync.service.spec.ts
+++ b/nevo_server/src/sync/sync.service.spec.ts
@@ -5,17 +5,19 @@ import { PoolsService } from '../pools/pools.service';
 describe('SyncService', () => {
   let service: SyncService;
   const upsertFromChain = jest.fn();
+  const markCompleted = jest.fn();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SyncService,
-        { provide: PoolsService, useValue: { upsertFromChain } },
+        { provide: PoolsService, useValue: { upsertFromChain, markCompleted } },
       ],
     }).compile();
 
     service = module.get(SyncService);
     upsertFromChain.mockReset();
+    markCompleted.mockReset();
   });
 
   it('extracts contractPoolId, creatorWallet, and goal and calls upsertFromChain', async () => {
@@ -30,6 +32,31 @@ describe('SyncService', () => {
       contractPoolId: 'pool-42',
       creatorWallet: 'GABC123',
       goal: '50000',
+    });
+  });
+
+  describe('processPoolClosedEvent', () => {
+    it('extracts contractPoolId from topic and calls markCompleted', async () => {
+      const event: HorizonContractEvent = {
+        topic: ['pool_cls', 'pool-99'],
+        value: [],
+      };
+
+      await service.processPoolClosedEvent(event);
+
+      expect(markCompleted).toHaveBeenCalledWith('pool-99');
+    });
+
+    it('calls markCompleted with the correct id for different pool ids', async () => {
+      const event: HorizonContractEvent = {
+        topic: ['pool_cls', 'pool-7'],
+        value: [],
+      };
+
+      await service.processPoolClosedEvent(event);
+
+      expect(markCompleted).toHaveBeenCalledTimes(1);
+      expect(markCompleted).toHaveBeenCalledWith('pool-7');
     });
   });
 });

--- a/nevo_server/src/sync/sync.service.ts
+++ b/nevo_server/src/sync/sync.service.ts
@@ -34,4 +34,9 @@ export class SyncService {
       goal,
     });
   }
+
+  async processPoolClosedEvent(event: HorizonContractEvent): Promise<void> {
+    const contractPoolId = event.topic[1];
+    await this.poolsService.markCompleted(contractPoolId);
+  }
 }


### PR DESCRIPTION
Closes #573 — Pool Comments/Discussion Section (Frontend)
- Added Comment/Reply data types and MOCK_COMMENTS stub in nevo_frontend/app/pools/[id]/page.tsx (marked with TODO to replace with real API calls once backend is implemented).
- Added a 'Discussion' section between Contributors and History on the pool detail page, showing a live comment count.
- Built CommentsSection component: loads comments into local state, dispatches add/edit/delete via state handlers (all stubbed with apiClient TODO comments pointing to POST/PUT/DELETE /pools/:id/comments).
- Built CommentForm: textarea with submit/cancel; shows a 'connect wallet' prompt when no wallet is connected.
- Built CommentItem: displays author short-address, timestamp, edited indicator, nested replies with left-border visual treatment, edit/delete controls (own comments only), and a collapsible inline reply form. Replies are rendered recursively with isReply=true.
- All components are mobile-responsive using flex/gap Tailwind layout.

Closes #577 — Help/FAQ Page with Collapsible Accordion (Frontend)
- Created nevo_frontend/app/help/page.tsx at route /help.
- Defined 14 FAQ items across four categories: General, Creating Pools, Donating, Withdrawals, and Blockchain.
- Built AccordionItem: uses aria-expanded/aria-controls/role=region for accessible expand/collapse; chevron icon rotates 180 degrees on open via Tailwind transition.
- Live search input filters across question and answer text simultaneously (case-insensitive).
- Category tab strip (All + each category) filters visible items; active tab styled with brand-600 background.
- Items with no matches show an empty state with a 'Clear search' button.
- FAQ groups are rendered per category with labelled section headings.
- Contact support block at the bottom links to mailto:hello@nevo.app and the /about page.
- Fully mobile responsive; no new dependencies introduced.

Closes #579 — Blockchain Explorer Integration (Frontend)
- Modified nevo_frontend/app/transactions/page.tsx.
- Added STELLAR_EXPERT_BASE constant pointing to https://stellar.expert/explorer/testnet/tx (easily swapped to mainnet when the network is promoted).
- Added ExternalLinkIcon SVG component (14px, aria-hidden).
- Updated TransactionRow to build an explorerUrl from the tx hash and render an accessible 'Explorer' anchor link inline next to the copy button; opens in a new tab with rel=noopener noreferrer. The aria-label includes the short hash and the note 'opens in new tab' for screen reader users.
- Transaction hash display, copy, and explorer link are all co-located in a single flex row for visual clarity.

Closes #688 — processPoolClosedEvent() in SyncService (Backend)
- nevo_server/src/pools/pools.service.ts: added markCompleted() method. Finds the Pool by contractPoolId; if found, sets pool.status = PoolStatus.Completed and saves via the repository. Returns null when the pool does not exist (safe no-op).
- nevo_server/src/sync/sync.service.ts: added processPoolClosedEvent() method. Extracts contractPoolId from event.topic[1] (matching the pool_cls event shape) and delegates to poolsService.markCompleted().
- nevo_server/src/sync/sync.service.spec.ts: added a processPoolClosedEvent describe block with two tests — one that asserts markCompleted is called with the correct contractPoolId, and one that verifies it is called exactly once per event. Also exposed markCompleted on the PoolsService mock.
- nevo_server/src/pools/pools.service.spec.ts: added missing imports for Pool, PoolStatus, and ContractService (they were used in the file but not imported). Added a markCompleted describe block with two tests — sets status to Completed on a found pool, and returns null when the pool does not exist.