### PR TITLE
Feat/add donation sorting options to list endpoints

### DIFF
--- a/nevo_server/package-lock.json
+++ b/nevo_server/package-lock.json
@@ -3095,14 +3095,6 @@
         "@types/superagent": "^8.1.0"
       }
     },
-    "node_modules/@types/validator": {
-      "version": "13.15.10",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
-      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -4655,27 +4647,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/class-transformer": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/class-validator": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
-      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/validator": "^13.15.3",
-        "libphonenumber-js": "^1.11.1",
-        "validator": "^13.15.22"
-      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -7719,14 +7690,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/libphonenumber-js": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.7.tgz",
-      "integrity": "sha512-rvr3HIMdOgzhz1RFGjftji+wjoAFlzhqCNqJOU/MKTZQ8d9NZxAR/tI+0weDicyoucqVR0U1GCniqHJ0f8aM2A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10661,17 +10624,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/validator": {
-      "version": "13.15.35",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
-      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/nevo_server/src/app.module.ts
+++ b/nevo_server/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module.js';
 import { Donation } from './donations/donation.entity.js';
 import { Pool } from './pools/pool.entity.js';
 import { PoolsModule } from './pools/pools.module.js';
+import { DonationsModule } from './donations/donations.module.js';
 import { SyncModule } from './sync/sync.module.js';
 import { User } from './users/user.entity.js';
 
@@ -29,6 +30,7 @@ import { User } from './users/user.entity.js';
     AuthModule,
     SyncModule,
     PoolsModule,
+    DonationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/nevo_server/src/auth/auth.module.ts
+++ b/nevo_server/src/auth/auth.module.ts
@@ -1,16 +1,19 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import type { StringValue } from 'ms';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { JwtStrategy } from './jwt.strategy';
 import { NonceService } from './nonce.service';
 import { Nonce } from './nonce.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Nonce]),
+    PassportModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET ?? 'dev-secret',
       signOptions: {
@@ -19,7 +22,7 @@ import { Nonce } from './nonce.entity';
     }),
     UsersModule,
   ],
-  providers: [AuthService, NonceService],
+  providers: [AuthService, NonceService, JwtStrategy],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/nevo_server/src/auth/dto/verify-auth.dto.ts
+++ b/nevo_server/src/auth/dto/verify-auth.dto.ts
@@ -1,15 +1,5 @@
-import { IsNotEmpty, IsString } from 'class-validator';
-
 export class VerifyAuthDto {
-  @IsString()
-  @IsNotEmpty()
   publicKey: string;
-
-  @IsString()
-  @IsNotEmpty()
   nonce: string;
-
-  @IsString()
-  @IsNotEmpty()
   signature: string;
 }

--- a/nevo_server/src/donations/donations.controller.ts
+++ b/nevo_server/src/donations/donations.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param, Query, Request, UseGuards } from '@nestjs/common';
+import { StellarAuthGuard } from '../auth/stellar-auth.guard.js';
+import { DonationSortBy, DonationsService } from './donations.service.js';
+
+@Controller()
+export class DonationsController {
+  constructor(private readonly donationsService: DonationsService) {}
+
+  @Get('pools/:id/donations')
+  findByPool(
+    @Param('id') id: string,
+    @Query('sortBy') sortBy?: string,
+  ) {
+    const sort: DonationSortBy = sortBy === 'largest' ? 'largest' : 'newest';
+    return this.donationsService.findByPool(id, sort);
+  }
+
+  @UseGuards(StellarAuthGuard)
+  @Get('users/me/donations')
+  findMyDonations(
+    @Request() req: { user: { publicKey: string } },
+    @Query('sortBy') sortBy?: string,
+  ) {
+    const sort: DonationSortBy = sortBy === 'largest' ? 'largest' : 'newest';
+    return this.donationsService.findByDonor(req.user.publicKey, sort);
+  }
+}

--- a/nevo_server/src/donations/donations.module.ts
+++ b/nevo_server/src/donations/donations.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Donation } from './donation.entity.js';
 import { DonationsService } from './donations.service.js';
+import { DonationsController } from './donations.controller.js';
 import { ContractModule } from '../contract/contract.module.js';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Donation]), ContractModule],
   providers: [DonationsService],
+  controllers: [DonationsController],
   exports: [DonationsService],
 })
 export class DonationsModule {}

--- a/nevo_server/src/donations/donations.module.ts
+++ b/nevo_server/src/donations/donations.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Donation } from './donation.entity.js';
+import { DonationsService } from './donations.service.js';
+import { ContractModule } from '../contract/contract.module.js';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Donation]), ContractModule],
+  providers: [DonationsService],
+  exports: [DonationsService],
+})
+export class DonationsModule {}

--- a/nevo_server/src/donations/donations.service.ts
+++ b/nevo_server/src/donations/donations.service.ts
@@ -3,10 +3,34 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Donation } from './donation.entity.js';
 
+export type DonationSortBy = 'newest' | 'largest';
+
 @Injectable()
 export class DonationsService {
   constructor(
     @InjectRepository(Donation)
     private readonly donationRepo: Repository<Donation>,
   ) {}
+
+  async findByPool(poolId: string, sortBy: DonationSortBy = 'newest'): Promise<Donation[]> {
+    if (sortBy === 'largest') {
+      return this.donationRepo
+        .createQueryBuilder('d')
+        .where('d.poolId = :poolId', { poolId })
+        .orderBy('CAST(d.amount AS NUMERIC)', 'DESC')
+        .getMany();
+    }
+    return this.donationRepo.find({ where: { poolId }, order: { createdAt: 'DESC' } });
+  }
+
+  async findByDonor(donorWallet: string, sortBy: DonationSortBy = 'newest'): Promise<Donation[]> {
+    if (sortBy === 'largest') {
+      return this.donationRepo
+        .createQueryBuilder('d')
+        .where('d.donorWallet = :donorWallet', { donorWallet })
+        .orderBy('CAST(d.amount AS NUMERIC)', 'DESC')
+        .getMany();
+    }
+    return this.donationRepo.find({ where: { donorWallet }, order: { createdAt: 'DESC' } });
+  }
 }

--- a/nevo_server/src/donations/donations.service.ts
+++ b/nevo_server/src/donations/donations.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Donation } from './donation.entity.js';
+
+@Injectable()
+export class DonationsService {
+  constructor(
+    @InjectRepository(Donation)
+    private readonly donationRepo: Repository<Donation>,
+  ) {}
+}

--- a/nevo_server/src/users/user.entity.ts
+++ b/nevo_server/src/users/user.entity.ts
@@ -16,8 +16,8 @@ export class User {
   @Column({ name: 'public_key', type: 'varchar', length: 56 })
   publicKey: string;
 
-  @Column({ type: 'varchar', length: 255, nullable: true })
-  username: string | null;
+  @Column({ name: 'username', type: 'varchar', length: 255, nullable: true })
+  displayName: string | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/nevo_server/src/users/users.controller.ts
+++ b/nevo_server/src/users/users.controller.ts
@@ -1,0 +1,37 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  NotFoundException,
+  Patch,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { StellarAuthGuard } from '../auth/stellar-auth.guard.js';
+import { UsersService } from './users.service.js';
+
+export interface UpdateDisplayNameDto {
+  displayName: string;
+}
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @UseGuards(StellarAuthGuard)
+  @Patch('me')
+  async updateMe(
+    @Request() req: { user: { publicKey: string } },
+    @Body() dto: UpdateDisplayNameDto,
+  ) {
+    if (!dto.displayName || dto.displayName.length > 50) {
+      throw new BadRequestException('displayName must be 1–50 characters');
+    }
+    const user = await this.usersService.updateDisplayName(
+      req.user.publicKey,
+      dto.displayName,
+    );
+    if (!user) throw new NotFoundException('User not found');
+    return user;
+  }
+}

--- a/nevo_server/src/users/users.module.ts
+++ b/nevo_server/src/users/users.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './user.entity';
 import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   providers: [UsersService],
+  controllers: [UsersController],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/nevo_server/src/users/users.service.ts
+++ b/nevo_server/src/users/users.service.ts
@@ -15,7 +15,7 @@ export class UsersService {
     if (existing) return existing;
 
     return this.userRepo.save(
-      this.userRepo.create({ publicKey, username: null }),
+      this.userRepo.create({ publicKey, displayName: null }),
     );
   }
 }

--- a/nevo_server/src/users/users.service.ts
+++ b/nevo_server/src/users/users.service.ts
@@ -10,6 +10,13 @@ export class UsersService {
     private readonly userRepo: Repository<User>,
   ) {}
 
+  async updateDisplayName(publicKey: string, displayName: string): Promise<User | null> {
+    const user = await this.userRepo.findOne({ where: { publicKey } });
+    if (!user) return null;
+    user.displayName = displayName;
+    return this.userRepo.save(user);
+  }
+
   async findOrCreate(publicKey: string): Promise<User> {
     const existing = await this.userRepo.findOne({ where: { publicKey } });
     if (existing) return existing;


### PR DESCRIPTION
---
  Add donation sorting, User entity, ContractModule wiring, and PATCH /users/me

  Summary

  - User entity (#666): renamed username field to displayName on the TypeORM entity, mapped to the existing username DB column so no migration is needed. Updated UsersService.findOrCreate accordingly.
  - ContractModule & DonationsModule wiring (#671): ContractModule/ContractService already existed and exported correctly. Created DonationsModule and DonationsService boilerplate, imported ContractModule into it, and
  registered DonationsModule in AppModule. (PoolsModule already imported ContractModule.)
  - PATCH /users/me (#669): Added UsersController with a JWT-guarded PATCH /users/me endpoint that accepts { displayName: string } (max 50 chars) and saves to DB. Added updateDisplayName method to UsersService. Registered
  JwtStrategy and PassportModule in AuthModule so StellarAuthGuard works correctly.
  - Donation sorting (#664): Added GET /pools/:id/donations?sortBy=newest|largest and GET /users/me/donations?sortBy=newest|largest (JWT-guarded) via a new DonationsController. The newest sort orders by createdAt DESC;
  largest casts the varchar amount to NUMERIC for a correct numeric DESC sort.

  Closes

  Closes #664
  Closes #666
  Closes #669
  Closes #671

  ---
   ▎ Pre-existing fix: src/auth/dto/verify-auth.dto.ts imported class-validator (not in package.json), blocking npm run build. Removed the unused decorators since the DTO is not imported anywhere.