### PR TITLE
feat(pools): show EmptyState when pools API returns zero results

### DIFF
--- a/nevo_frontend/app/pools/page.tsx
+++ b/nevo_frontend/app/pools/page.tsx
@@ -687,18 +687,34 @@ export default function BrowsePoolsPage() {
               variant="bordered"
               icon="search"
               iconTone="muted"
-              title="No results found"
-              description="No pools match the current filter combination."
-              action={{
-                label: 'Clear all filters',
-                onClick: clearAllFilters,
-                variant: 'primary',
-              }}
-              secondaryAction={{
-                label: 'Create a Pool',
-                href: '/pools/new',
-                variant: 'link',
-              }}
+              title="No pools found"
+              description={
+                activeFilters.length > 0
+                  ? 'No pools match the current filter combination.'
+                  : 'There are no donation pools yet. Be the first to create one.'
+              }
+              action={
+                activeFilters.length > 0
+                  ? {
+                      label: 'Clear filters',
+                      onClick: clearAllFilters,
+                      variant: 'primary',
+                    }
+                  : {
+                      label: 'Create a Pool',
+                      href: '/pools/new',
+                      variant: 'primary',
+                    }
+              }
+              secondaryAction={
+                activeFilters.length > 0
+                  ? {
+                      label: 'Create a Pool',
+                      href: '/pools/new',
+                      variant: 'link',
+                    }
+                  : undefined
+              }
             />
           ) : (
             <div className="space-y-8">


### PR DESCRIPTION
Closes #710

## Problem
When the pools API returned zero results (either because no pools exist or because no pools matched the active filters), the grid area was completely blank. There was no visual feedback to the user about what happened or what they could do next.

## What was changed
File: nevo_frontend/app/pools/page.tsx

The existing empty grid branch (sortedPools.length === 0) was already wired up to render <EmptyState>, but its copy and action logic did not distinguish between two distinct situations:

1. The API returned zero pools and no filters are active — the user is looking at a genuinely empty platform (or their search returned nothing with no filters applied).
2. The current filter combination produced zero results — filters are active and are responsible for the empty state.

## How it was fixed
The EmptyState render block was updated to branch on activeFilters.length:

  When activeFilters.length > 0  (filters are active):
  - title:       'No pools found'
  - description: 'No pools match the current filter combination.'
  - Primary CTA: 'Clear filters' button -> calls clearAllFilters()
  - Secondary CTA: 'Create a Pool' link -> /pools/new (link variant)

  When activeFilters.length === 0  (no filters, API truly empty):
  - title:       'No pools found'
  - description: 'There are no donation pools yet. Be the first to create one.'
  - Primary CTA: 'Create a Pool' link -> /pools/new (primary variant)
  - No secondary action (nothing to clear)

This satisfies the deliverables from issue #710:
  - pools.length === 0 and loading === false -> renders EmptyState with message 'No pools found' (handled upstream by sortedPools being empty)
  - 'Clear filters' button is only shown when activeFilters.length > 0
  - npm run build passes (verified locally, exit code 0)