### PR TITLE
Feat/391 form components

### DIFF
--- a/nevo_frontend/__tests__/FormComponents.test.tsx
+++ b/nevo_frontend/__tests__/FormComponents.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  Checkbox,
+  FormField,
+  Input,
+  Select,
+  Textarea,
+} from '@/components/form';
+
+describe('Form components', () => {
+  describe('Input', () => {
+    it('renders text input', () => {
+      render(<Input label="Title" />);
+      expect(screen.getByLabelText(/Title/)).toHaveAttribute('type', 'text');
+    });
+
+    it('renders email, number, and password types', () => {
+      const { rerender } = render(<Input type="email" label="Email" />);
+      expect(screen.getByLabelText(/Email/)).toHaveAttribute('type', 'email');
+
+      rerender(<Input type="number" label="Amount" />);
+      expect(screen.getByLabelText(/Amount/)).toHaveAttribute('type', 'number');
+
+      rerender(<Input type="password" label="Password" />);
+      expect(screen.getByLabelText(/Password/)).toHaveAttribute(
+        'type',
+        'password'
+      );
+    });
+
+    it('renders label, helper text, and required indicator', () => {
+      render(
+        <Input label="Email" helperText="We never share your email." required />
+      );
+      expect(screen.getByLabelText(/Email/)).toBeRequired();
+      expect(screen.getByText('*')).toBeInTheDocument();
+      expect(
+        screen.getByText('We never share your email.')
+      ).toBeInTheDocument();
+    });
+
+    it('shows error state with alert message', () => {
+      render(<Input label="Name" error="Name is required" />);
+      const input = screen.getByLabelText(/Name/);
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByRole('alert')).toHaveTextContent('Name is required');
+    });
+
+    it('accepts keyboard input', async () => {
+      render(<Input label="Title" />);
+      const input = screen.getByLabelText(/Title/);
+      await userEvent.type(input, 'Clean Water');
+      expect(input).toHaveValue('Clean Water');
+    });
+  });
+
+  describe('Textarea', () => {
+    it('renders multi-line input with label', async () => {
+      render(<Textarea label="Description" placeholder="Describe..." />);
+      const textarea = screen.getByLabelText(/Description/);
+      expect(textarea.tagName).toBe('TEXTAREA');
+      await userEvent.type(textarea, 'Hello\nWorld');
+      expect(textarea).toHaveValue('Hello\nWorld');
+    });
+
+    it('shows error message', () => {
+      render(<Textarea label="Bio" error="Bio is too short" />);
+      expect(screen.getByRole('alert')).toHaveTextContent('Bio is too short');
+    });
+  });
+
+  describe('Select', () => {
+    const options = [
+      { label: 'Education', value: 'education' },
+      { label: 'Health', value: 'health' },
+    ];
+
+    it('renders options with placeholder', () => {
+      render(
+        <Select
+          label="Category"
+          placeholder="Select a category"
+          options={options}
+        />
+      );
+      expect(screen.getByLabelText(/Category/)).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: 'Select a category' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: 'Education' })
+      ).toBeInTheDocument();
+    });
+
+    it('supports keyboard selection', async () => {
+      render(<Select label="Category" options={options} />);
+      const select = screen.getByLabelText(/Category/);
+      await userEvent.selectOptions(select, 'health');
+      expect(select).toHaveValue('health');
+    });
+
+    it('shows error state', () => {
+      render(
+        <Select label="Category" options={options} error="Pick a category" />
+      );
+      expect(screen.getByRole('alert')).toHaveTextContent('Pick a category');
+    });
+  });
+
+  describe('Checkbox', () => {
+    it('associates label with checkbox for accessibility', async () => {
+      const onChange = jest.fn();
+      render(
+        <Checkbox
+          label="Accept terms"
+          helperText="Required to continue."
+          onChange={onChange}
+        />
+      );
+      const checkbox = screen.getByRole('checkbox', { name: /Accept terms/ });
+      expect(checkbox).not.toBeChecked();
+      await userEvent.click(checkbox);
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('shows error message and invalid state', () => {
+      render(<Checkbox label="Subscribe" error="You must subscribe" />);
+      expect(screen.getByRole('checkbox')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+      expect(screen.getByRole('alert')).toHaveTextContent('You must subscribe');
+    });
+
+    it('is keyboard focusable', () => {
+      render(<Checkbox label="Remember me" />);
+      const checkbox = screen.getByRole('checkbox');
+      checkbox.focus();
+      expect(checkbox).toHaveFocus();
+    });
+  });
+
+  describe('FormField', () => {
+    it('wraps custom controls with label and error', () => {
+      render(
+        <FormField id="custom" label="Custom" error="Invalid">
+          <input id="custom" />
+        </FormField>
+      );
+      expect(screen.getByText('Custom')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent('Invalid');
+    });
+  });
+});

--- a/nevo_frontend/app/pools/new/page.tsx
+++ b/nevo_frontend/app/pools/new/page.tsx
@@ -3,10 +3,9 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ProtectedRoute from '@/components/ProtectedRoute';
-import { createPool } from '@/lib/api-client';
+import { createPool, submitSignedXdr } from '@/lib/api-client';
 import { signTransaction } from '@stellar/freighter-api';
 import { contractService } from '@/lib/contract-service';
-import { createPool, submitSignedXdr } from '@/lib/api-client';
 import { useWalletStore } from '@/src/store/walletStore';
 import {
   validateFormData,
@@ -334,21 +333,6 @@ function CreatePoolPageContent() {
       setSubmitting(false);
       setSubmitStep('idle');
     }
-    try {
-      await createPool({
-        title: form.title,
-        description: form.description,
-        category: form.category,
-        goalAmount: form.goalAmount,
-        duration: form.duration,
-        imageUrl: form.imageUrl,
-        tags: form.tags,
-      });
-    } catch {
-      // TODO: surface error to user once error UI is designed
-    }
-    setSubmitting(false);
-    setSubmitted(true);
   }
 
   if (submitted) {

--- a/nevo_frontend/components/form/Checkbox.tsx
+++ b/nevo_frontend/components/form/Checkbox.tsx
@@ -1,0 +1,87 @@
+import React, { forwardRef, InputHTMLAttributes, useId } from 'react';
+import { getCheckboxClassName } from './form-styles';
+
+export interface CheckboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type'
+> {
+  label: string;
+  helperText?: string;
+  error?: string;
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  (
+    {
+      label,
+      helperText,
+      error,
+      className = '',
+      id: idProp,
+      required = false,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
+    const hasError = Boolean(error);
+    const helperId = helperText ? `${id}-helper` : undefined;
+    const errorId = error ? `${id}-error` : undefined;
+    const describedBy =
+      [helperId, errorId].filter(Boolean).join(' ') || undefined;
+
+    return (
+      <div className={className}>
+        <div className="flex items-start gap-2.5">
+          <input
+            ref={ref}
+            id={id}
+            type="checkbox"
+            required={required}
+            aria-invalid={hasError || undefined}
+            aria-required={required || undefined}
+            aria-describedby={describedBy}
+            className={getCheckboxClassName(hasError)}
+            {...props}
+          />
+          <div className="min-w-0 flex-1">
+            <label
+              htmlFor={id}
+              className="text-sm font-medium text-[var(--color-text)] cursor-pointer"
+            >
+              {label}
+              {required && (
+                <span
+                  className="ml-1 text-[var(--color-error)]"
+                  aria-hidden="true"
+                >
+                  *
+                </span>
+              )}
+            </label>
+            {helperText && (
+              <p
+                id={helperId}
+                className="mt-0.5 text-xs text-[var(--color-text-muted)]"
+              >
+                {helperText}
+              </p>
+            )}
+          </div>
+        </div>
+        {error && (
+          <p
+            id={errorId}
+            role="alert"
+            className="mt-1 text-xs text-[var(--color-error)]"
+          >
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+Checkbox.displayName = 'Checkbox';

--- a/nevo_frontend/components/form/FormField.tsx
+++ b/nevo_frontend/components/form/FormField.tsx
@@ -1,0 +1,71 @@
+import React, { ReactNode } from 'react';
+
+export interface FormFieldProps {
+  id: string;
+  label?: string;
+  required?: boolean;
+  error?: string;
+  helperText?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function FormField({
+  id,
+  label,
+  required = false,
+  error,
+  helperText,
+  children,
+  className = '',
+}: FormFieldProps) {
+  const helperId = helperText ? `${id}-helper` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy =
+    [helperId, errorId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <div className={className}>
+      {label && (
+        <label
+          htmlFor={id}
+          className="mb-1.5 block text-sm font-medium text-[var(--color-text)]"
+        >
+          {label}
+          {required && (
+            <span className="ml-1 text-[var(--color-error)]" aria-hidden="true">
+              *
+            </span>
+          )}
+        </label>
+      )}
+      {helperText && (
+        <p
+          id={helperId}
+          className="mb-1.5 text-xs text-[var(--color-text-muted)]"
+        >
+          {helperText}
+        </p>
+      )}
+      {React.isValidElement(children)
+        ? describedBy
+          ? React.cloneElement(
+              children as React.ReactElement<{ 'aria-describedby'?: string }>,
+              {
+                'aria-describedby': describedBy,
+              }
+            )
+          : children
+        : children}
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          className="mt-1 text-xs text-[var(--color-error)]"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/nevo_frontend/components/form/Input.tsx
+++ b/nevo_frontend/components/form/Input.tsx
@@ -1,0 +1,67 @@
+import React, { forwardRef, InputHTMLAttributes, useId } from 'react';
+import { FormField } from './FormField';
+import { getControlClassName } from './form-styles';
+
+export type InputType = 'text' | 'email' | 'number' | 'password';
+
+export interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type'
+> {
+  type?: InputType;
+  label?: string;
+  helperText?: string;
+  error?: string;
+  required?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      type = 'text',
+      label,
+      helperText,
+      error,
+      required = false,
+      className = '',
+      id: idProp,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
+    const hasError = Boolean(error);
+
+    const input = (
+      <input
+        ref={ref}
+        id={id}
+        type={type}
+        required={required}
+        aria-invalid={hasError || undefined}
+        aria-required={required || undefined}
+        className={getControlClassName(hasError, className)}
+        {...props}
+      />
+    );
+
+    if (label || helperText || error) {
+      return (
+        <FormField
+          id={id}
+          label={label}
+          helperText={helperText}
+          error={error}
+          required={required}
+        >
+          {input}
+        </FormField>
+      );
+    }
+
+    return input;
+  }
+);
+
+Input.displayName = 'Input';

--- a/nevo_frontend/components/form/Select.tsx
+++ b/nevo_frontend/components/form/Select.tsx
@@ -1,0 +1,87 @@
+import React, { forwardRef, SelectHTMLAttributes, useId } from 'react';
+import { FormField } from './FormField';
+import { getSelectClassName } from './form-styles';
+
+export interface SelectOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+export interface SelectProps extends Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  'children'
+> {
+  options: SelectOption[];
+  placeholder?: string;
+  label?: string;
+  helperText?: string;
+  error?: string;
+  required?: boolean;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  (
+    {
+      options,
+      placeholder,
+      label,
+      helperText,
+      error,
+      required = false,
+      className = '',
+      id: idProp,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
+    const hasError = Boolean(error);
+
+    const select = (
+      <select
+        ref={ref}
+        id={id}
+        required={required}
+        aria-invalid={hasError || undefined}
+        aria-required={required || undefined}
+        className={getSelectClassName(hasError, className)}
+        {...props}
+      >
+        {placeholder && (
+          <option value="" disabled>
+            {placeholder}
+          </option>
+        )}
+        {options.map((option) => (
+          <option
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </option>
+        ))}
+      </select>
+    );
+
+    if (label || helperText || error) {
+      return (
+        <FormField
+          id={id}
+          label={label}
+          helperText={helperText}
+          error={error}
+          required={required}
+        >
+          {select}
+        </FormField>
+      );
+    }
+
+    return select;
+  }
+);
+
+Select.displayName = 'Select';

--- a/nevo_frontend/components/form/Textarea.tsx
+++ b/nevo_frontend/components/form/Textarea.tsx
@@ -1,0 +1,64 @@
+import React, { forwardRef, TextareaHTMLAttributes, useId } from 'react';
+import { FormField } from './FormField';
+import { getControlClassName } from './form-styles';
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  helperText?: string;
+  error?: string;
+  required?: boolean;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      label,
+      helperText,
+      error,
+      required = false,
+      className = '',
+      id: idProp,
+      rows = 4,
+      ...props
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const id = idProp ?? generatedId;
+    const hasError = Boolean(error);
+
+    const textarea = (
+      <textarea
+        ref={ref}
+        id={id}
+        rows={rows}
+        required={required}
+        aria-invalid={hasError || undefined}
+        aria-required={required || undefined}
+        className={getControlClassName(
+          hasError,
+          `${className} resize-y`.trim()
+        )}
+        {...props}
+      />
+    );
+
+    if (label || helperText || error) {
+      return (
+        <FormField
+          id={id}
+          label={label}
+          helperText={helperText}
+          error={error}
+          required={required}
+        >
+          {textarea}
+        </FormField>
+      );
+    }
+
+    return textarea;
+  }
+);
+
+Textarea.displayName = 'Textarea';

--- a/nevo_frontend/components/form/form-styles.ts
+++ b/nevo_frontend/components/form/form-styles.ts
@@ -1,0 +1,37 @@
+export function getControlClassName(hasError: boolean, className = ''): string {
+  return [
+    'w-full rounded-xl border px-3.5 py-2.5 text-sm',
+    'bg-[var(--color-surface)] text-[var(--color-text)]',
+    'placeholder:text-[var(--color-text-muted)]',
+    'focus:outline-none focus:ring-2 transition-colors',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    hasError
+      ? 'border-[var(--color-error)] focus:ring-[var(--color-error)]'
+      : 'border-[var(--color-border)] focus:ring-brand-500',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function getSelectClassName(hasError: boolean, className = ''): string {
+  return [
+    getControlClassName(hasError),
+    'appearance-none bg-[length:1rem] bg-[right_0.75rem_center] bg-no-repeat pr-10',
+    "bg-[url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E\")]",
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function getCheckboxClassName(hasError: boolean): string {
+  return [
+    'h-4 w-4 shrink-0 rounded border',
+    'text-brand-600 focus:ring-2 focus:ring-offset-0',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    hasError
+      ? 'border-[var(--color-error)] focus:ring-[var(--color-error)]'
+      : 'border-[var(--color-border)] focus:ring-brand-500',
+  ].join(' ');
+}

--- a/nevo_frontend/components/form/index.ts
+++ b/nevo_frontend/components/form/index.ts
@@ -1,0 +1,6 @@
+export * from './FormField';
+export * from './Input';
+export * from './Textarea';
+export * from './Select';
+export * from './Checkbox';
+export * from './form-styles';

--- a/nevo_frontend/components/index.ts
+++ b/nevo_frontend/components/index.ts
@@ -16,3 +16,4 @@ export * from './EmptyState';
 export * from './Card';
 export * from './PoolCard';
 export * from './Pagination';
+export * from './form';


### PR DESCRIPTION
## Summary
- Adds reusable form components under `components/form/` with Nevo design tokens
- Supports labels, required indicators, helper text, and error states with full keyboard accessibility
- Includes unit tests for all form controls
- Fixes a duplicate `createPool` import in pool creation that was blocking the frontend build
Closes #391
## Test plan
- [ ] Import and render Input, Textarea, Select, and Checkbox with error states
- [ ] Verify keyboard navigation and focus styling
- [ ] Run `npm test -- FormComponents`
- [ ] Run `npm run build` from `nevo_frontend/`
