### PR TITLE
feat(sync): add idempotency to Horizon sync using transaction hash (#…

### DIFF
--- a/nevo_server/src/donations/donations.service.ts
+++ b/nevo_server/src/donations/donations.service.ts
@@ -45,4 +45,9 @@ export class DonationsService {
       order: { createdAt: 'DESC' },
     });
   }
+
+  async isTxProcessed(txHash: string): Promise<boolean> {
+    const count = await this.donationRepo.countBy({ txHash });
+    return count > 0;
+  }
 }

--- a/nevo_server/src/sync/sync.module.ts
+++ b/nevo_server/src/sync/sync.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PoolsModule } from '../pools/pools.module.js';
+import { DonationsModule } from '../donations/donations.module.js';
 import { SyncService } from './sync.service.js';
 import { SyncState } from './sync-state.entity.js';
 
 @Module({
-  imports: [ScheduleModule.forRoot(), PoolsModule, TypeOrmModule.forFeature([SyncState])],
+  imports: [ScheduleModule.forRoot(), PoolsModule, DonationsModule, TypeOrmModule.forFeature([SyncState])],
   providers: [SyncService],
   exports: [SyncService],
 })

--- a/nevo_server/src/sync/sync.service.spec.ts
+++ b/nevo_server/src/sync/sync.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SyncService, HorizonContractEvent } from './sync.service';
 import { PoolsService } from '../pools/pools.service';
+import { DonationsService } from '../donations/donations.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { SyncState } from './sync-state.entity';
 
@@ -8,12 +9,14 @@ describe('SyncService', () => {
   let service: SyncService;
   const upsertFromChain = jest.fn();
   const markCompleted = jest.fn();
+  const isTxProcessed = jest.fn();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SyncService,
         { provide: PoolsService, useValue: { upsertFromChain, markCompleted } },
+        { provide: DonationsService, useValue: { isTxProcessed } },
         { provide: getRepositoryToken(SyncState), useValue: { findOne: jest.fn(), save: jest.fn() } },
       ],
     }).compile();
@@ -21,6 +24,7 @@ describe('SyncService', () => {
     service = module.get(SyncService);
     upsertFromChain.mockReset();
     markCompleted.mockReset();
+    isTxProcessed.mockReset().mockResolvedValue(false);
   });
 
   it('extracts contractPoolId, creatorWallet, and goal and calls upsertFromChain', async () => {
@@ -60,6 +64,74 @@ describe('SyncService', () => {
 
       expect(markCompleted).toHaveBeenCalledTimes(1);
       expect(markCompleted).toHaveBeenCalledWith('pool-7');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('skips processPoolCreatedEvent when tx is already in DB', async () => {
+      isTxProcessed.mockResolvedValue(true);
+      const event: HorizonContractEvent = {
+        topic: ['pool_crtd', 'pool-1'],
+        value: ['GABC', '100'],
+        txHash: 'abc123',
+      };
+
+      await service.processPoolCreatedEvent(event);
+
+      expect(upsertFromChain).not.toHaveBeenCalled();
+    });
+
+    it('skips processPoolClosedEvent when tx is already in DB', async () => {
+      isTxProcessed.mockResolvedValue(true);
+      const event: HorizonContractEvent = {
+        topic: ['pool_cls', 'pool-1'],
+        value: [],
+        txHash: 'abc123',
+      };
+
+      await service.processPoolClosedEvent(event);
+
+      expect(markCompleted).not.toHaveBeenCalled();
+    });
+
+    it('processes event when txHash is new', async () => {
+      isTxProcessed.mockResolvedValue(false);
+      const event: HorizonContractEvent = {
+        topic: ['pool_crtd', 'pool-2'],
+        value: ['GXYZ', '200'],
+        txHash: 'newhash',
+      };
+
+      await service.processPoolCreatedEvent(event);
+
+      expect(upsertFromChain).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns and skips on duplicate txHash within the same run', async () => {
+      const loggerWarnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+      const event: HorizonContractEvent = {
+        topic: ['pool_crtd', 'pool-3'],
+        value: ['GDUP', '300'],
+        txHash: 'dup-hash',
+      };
+
+      await service.processPoolCreatedEvent(event);
+      await service.processPoolCreatedEvent(event);
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('dup-hash'));
+      expect(upsertFromChain).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes event without txHash (no idempotency check)', async () => {
+      const event: HorizonContractEvent = {
+        topic: ['pool_crtd', 'pool-4'],
+        value: ['GNOHASH', '400'],
+      };
+
+      await service.processPoolCreatedEvent(event);
+
+      expect(isTxProcessed).not.toHaveBeenCalled();
+      expect(upsertFromChain).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/nevo_server/src/sync/sync.service.ts
+++ b/nevo_server/src/sync/sync.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { PoolsService } from '../pools/pools.service.js';
+import { DonationsService } from '../donations/donations.service.js';
 import { SyncState } from './sync-state.entity.js';
 
 /** Minimal shape of a Stellar Horizon Soroban contract event. */
@@ -14,14 +15,20 @@ export interface HorizonContractEvent {
    * For pool_crtd: [creatorWallet, goal, title, description]
    */
   value: string[];
+  /** Transaction hash for idempotency — may be undefined for non-donation events. */
+  txHash?: string;
 }
 
 @Injectable()
 export class SyncService implements OnModuleInit {
+  private readonly logger = new Logger(SyncService.name);
   private currentCursor: string | null = null;
+  /** Tracks tx hashes seen in the current poll run to detect within-run duplicates. */
+  private seenInRun = new Set<string>();
 
   constructor(
     private readonly poolsService: PoolsService,
+    private readonly donationsService: DonationsService,
     @InjectRepository(SyncState)
     private readonly syncStateRepo: Repository<SyncState>,
   ) {}
@@ -45,10 +52,33 @@ export class SyncService implements OnModuleInit {
   // TODO: replace with real implementation once HorizonService (#46) is available
   @Cron(CronExpression.EVERY_MINUTE)
   async pollHorizonEvents(): Promise<void> {
+    this.seenInRun.clear();
     // stub — will call HorizonService.fetchContractEvents() when implemented
   }
 
+  /**
+   * Returns true if the tx should be skipped (already processed or duplicate in this run).
+   * Logs a warning when the same hash appears more than once in a single run.
+   */
+  async isTxDuplicate(txHash: string): Promise<boolean> {
+    if (this.seenInRun.has(txHash)) {
+      this.logger.warn(`Duplicate tx hash in current run: ${txHash}`);
+      return true;
+    }
+    this.seenInRun.add(txHash);
+
+    const alreadyProcessed = await this.donationsService.isTxProcessed(txHash);
+    if (alreadyProcessed) {
+      return true;
+    }
+    return false;
+  }
+
   async processPoolCreatedEvent(event: HorizonContractEvent): Promise<void> {
+    if (event.txHash && (await this.isTxDuplicate(event.txHash))) {
+      return;
+    }
+
     const contractPoolId = event.topic[1];
     const creatorWallet = event.value[0];
     const goal = event.value[1];
@@ -61,6 +91,10 @@ export class SyncService implements OnModuleInit {
   }
 
   async processPoolClosedEvent(event: HorizonContractEvent): Promise<void> {
+    if (event.txHash && (await this.isTxDuplicate(event.txHash))) {
+      return;
+    }
+
     const contractPoolId = event.topic[1];
     await this.poolsService.markCompleted(contractPoolId);
   }


### PR DESCRIPTION
…689)

- Add isTxProcessed(txHash) to DonationsService (queries donations table)
- Inject DonationsService into SyncService
- Add isTxDuplicate(): skips silently if tx already in DB, warns if seen twice in same run
- Guard processPoolCreatedEvent and processPoolClosedEvent with isTxDuplicate
- Import DonationsModule in SyncModule
- Add idempotency tests to sync.service.spec.ts
closes #689 