### PR TITLE
[805] [S4] Add a CI step that fails if any MOCK_ constant remains in app or store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check for remaining mock data
+        working-directory: ./nevo_frontend
+        run: |
+          if grep -r "MOCK_" app/ src/store/ \
+            --include="*.ts" \
+            --include="*.tsx" -l; then
+            echo "ERROR: MOCK_ constants found. Remove all mock data before merging to main."
+            exit 1
+          fi
+
   server:
     name: Server — Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a CI step to the frontend job that greps `app/` and `src/store/` for any remaining `MOCK_` constants in `.ts`/`.tsx` files
- Fails the build with a clear error message if mock data is detected
- Current main branch passes this check (no `MOCK_` constants remain)

## CI workflow changes

After the frontend build step, a new step runs:

```yaml
- name: Check for remaining mock data
  working-directory: ./nevo_frontend
  run: |
    if grep -r "MOCK_" app/ src/store/ \
      --include="*.ts" \
      --include="*.tsx" -l; then
      echo "ERROR: MOCK_ constants found. Remove all mock data before merging to main."
      exit 1
    fi
```

## Dependency on #696

This guard assumes Stage 4 mock replacement from issue #696 is complete. The check enforces that no `MOCK_` constants slip back into `app/` or `src/store/` after that cleanup.

## Validation results

- Grep check passes on current main (no false positives)
- Verified a sample `MOCK_` file is correctly detected and would fail CI
- No frontend source modifications in this PR

Closes #805

Made with [Cursor](https://cursor.com)