### PR TITLE
[807] [S4] Add server-side request logging middleware to NestJS

### DIFF
--- a/nevo_server/src/app.module.ts
+++ b/nevo_server/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -6,6 +6,7 @@ import { AppController } from './app.controller.js';
 import { AppService } from './app.service.js';
 import { AuthModule } from './auth/auth.module.js';
 import { ContractModule } from './contract/contract.module.js';
+import { LoggingMiddleware } from './common/logging.middleware.js';
 import { Donation } from './donations/donation.entity.js';
 import { DonationsModule } from './donations/donations.module.js';
 import { Pool } from './pools/pool.entity.js';
@@ -43,4 +44,8 @@ import { UsersModule } from './users/users.module.js';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(LoggingMiddleware).forRoutes('*');
+  }
+}

--- a/nevo_server/src/common/logging.middleware.ts
+++ b/nevo_server/src/common/logging.middleware.ts
@@ -1,0 +1,20 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+
+@Injectable()
+export class LoggingMiddleware implements NestMiddleware {
+  private readonly logger = new Logger('HTTP');
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    const start = Date.now();
+
+    res.on('finish', () => {
+      const duration = Date.now() - start;
+      this.logger.log(
+        `${req.method} ${req.originalUrl || req.url} ${res.statusCode} ${duration}ms`,
+      );
+    });
+
+    next();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `LoggingMiddleware` implementing `NestMiddleware` in `nevo_server/src/common/logging.middleware.ts`
- Registers the middleware globally via `AppModule.configure(consumer)` for all routes

## Middleware implementation

Uses the NestJS built-in `Logger` (no third-party dependencies). On each request, logs after the response finishes:

```
[HTTP] GET /pools 200 12ms
```

Fields logged: HTTP method, request path, response status code, duration in milliseconds.

## Validation results

- `npm run build` passes
- ESLint passes on changed files
- `npm test` — 59 tests passed

Closes #807

Made with [Cursor](https://cursor.com)