### PR TITLE
[803] [S4] Add a GET /health endpoint to the NestJS server

### DIFF
--- a/nevo_server/src/app.controller.spec.ts
+++ b/nevo_server/src/app.controller.spec.ts
@@ -20,4 +20,14 @@ describe('AppController', () => {
       expect(appController.getHello()).toBe('Hello World!');
     });
   });
+
+  describe('health', () => {
+    it('should return ok status with timestamp', () => {
+      const result = appController.getHealth();
+      expect(result.status).toBe('ok');
+      expect(result.timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+    });
+  });
 });

--- a/nevo_server/src/app.controller.ts
+++ b/nevo_server/src/app.controller.ts
@@ -12,6 +12,14 @@ export class AppController {
     return this.appService.getHello();
   }
 
+  @Get('health')
+  getHealth() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
   @UseGuards(StellarAuthGuard)
   @Get('profile')
   getProfile(@Req() req: Request & { user?: { publicKey?: string } }) {


### PR DESCRIPTION
## Summary

- Adds a public `GET /health` endpoint to `AppController`
- No authentication required; always returns HTTP 200

## Health endpoint implementation

Response payload:

```json
{
  "status": "ok",
  "timestamp": "2026-06-29T19:30:00.000Z"
}
```

No additional packages added. Suitable for load balancer and uptime probes.

## Validation results

- `npm run build` passes
- Unit test added in `app.controller.spec.ts` (2 tests passing)
- Endpoint is public — no guards applied

Closes #803

Made with [Cursor](https://cursor.com)