### PR TITLE
feat: redirect to pool detail page after creation

### DIFF
--- a/nevo_frontend/app/pools/new/page.tsx
+++ b/nevo_frontend/app/pools/new/page.tsx
@@ -7,6 +7,7 @@ import { createPool, submitSignedXdr, ApiError } from '@/lib/api-client';
 import { signTransaction } from '@stellar/freighter-api';
 import { contractService } from '@/lib/contract-service';
 import { useWalletStore } from '@/src/store/walletStore';
+import { parseApiError } from '@/lib/errors';
 
 import {
   validateFormData,
@@ -130,7 +131,6 @@ function CreatePoolPageContent() {
   const [submitStep, setSubmitStep] = useState<
     'idle' | 'creating' | 'signing' | 'submitting'
   >('idle');
-  const [submitted, setSubmitted] = useState(false);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState('');
   const [cropPreviewUrl, setCropPreviewUrl] = useState('');
@@ -355,17 +355,14 @@ function CreatePoolPageContent() {
       setSubmitStep('submitting');
       await submitSignedXdr(signedResult.signedTxXdr);
 
-      setSubmitted(true);
+      // Redirect to the newly created pool's page after successful submission
+      router.push(`/pools/${createPoolResult.id}`);
     } catch (error) {
       setErrors({ submit: parseApiError(error) });
     } finally {
       setSubmitting(false);
       setSubmitStep('idle');
     }
-  }
-
-  if (submitted) {
-    return <SuccessScreen onGoToDashboard={() => router.push('/dashboard')} />;
   }
 
   const tagList = form.tags
@@ -948,28 +945,6 @@ function Step3({
         </div>
       )}
     </div>
-  );
-}
-
-/* ── Success screen ───────────────────────────────────────────────────────── */
-
-function SuccessScreen({ onGoToDashboard }: { onGoToDashboard: () => void }) {
-  return (
-    <main className="mx-auto max-w-2xl px-6 py-24 text-center">
-      <div className="flex flex-col items-center gap-4">
-        <div className="flex size-16 items-center justify-center rounded-full bg-success-light text-success">
-          <CheckCircleIcon />
-        </div>
-        <h1 className="text-2xl font-bold">Pool Created!</h1>
-        <p className="text-[var(--color-text-muted)] max-w-sm">
-          Your donation pool has been created successfully. Share it with your
-          community to start receiving contributions.
-        </p>
-        <button onClick={onGoToDashboard} className={`mt-4 ${primaryBtn}`}>
-          Go to Dashboard
-        </button>
-      </div>
-    </main>
   );
 }
 


### PR DESCRIPTION
After pool creation is confirmed on-chain, the user is now redirected to the newly created pool's detail page.

## Changes Made

- After `submitSignedXdr()` succeeds, redirect to `/pools/{poolId}` using `router.push()`
- Removed `SuccessScreen` component and `submitted` state since we now redirect directly
- Added `parseApiError` import for proper error handling
- Pool ID is captured from the `createPool()` response and used for the redirect

## Deliverables

- ✅ After `submitSignedXdr()` succeeds: calls `router.push(/pools/\${poolId})`
- ✅ TypeScript validation passes (no diagnostics in modified file)
- ✅ Code follows existing patterns in the file

## Testing

The implementation follows the existing flow:
1. User creates a pool (form submission)
2. `createPool()` API returns `{ id, unsignedXdr }`
3. User signs the transaction via Freighter
4. `submitSignedXdr()` submits the signed transaction
5. **NEW:** On success, redirect to `/pools/{poolId}` (pool detail page)

## Dependencies

Depends on #86 (`submitSignedXdr` implementation)

## Notes

- The pool ID comes from the original `createPool()` response as specified
- On error, the user remains on the form with error feedback
- The CI build will validate the changes properly with env vars configured

Closes #723 