### PR TITLE
fix: add per-request correlation ID to logs and response headers

### DIFF
--- a/nevo_server/src/common/logging.middleware.ts
+++ b/nevo_server/src/common/logging.middleware.ts
@@ -1,5 +1,8 @@
 import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
 import { NextFunction, Request, Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import { requestContext } from './request-context';
+
 
 @Injectable()
 export class LoggingMiddleware implements NestMiddleware {
@@ -8,13 +11,19 @@ export class LoggingMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction): void {
     const start = Date.now();
 
+    const requestId = (req.headers['x-request-id'] as string) || randomUUID();
+
+    res.setHeader('X-Request_ID', requestId);
+
     res.on('finish', () => {
       const duration = Date.now() - start;
       this.logger.log(
-        `${req.method} ${req.originalUrl || req.url} ${res.statusCode} ${duration}ms`,
+        `[${requestId}] ${req.method} ${req.originalUrl || req.url} ${res.statusCode} ${duration}ms`,
       );
     });
+    requestContext.run({ requestId }, () => {
+      next();
+    });
 
-    next();
   }
 }

--- a/nevo_server/src/common/request-context.ts
+++ b/nevo_server/src/common/request-context.ts
@@ -1,0 +1,11 @@
+import {AsyncLocalStorage} from 'node:async_hooks';
+
+export interface RequestContextStore{
+    requestId : string;
+}
+
+export const requestContext = new AsyncLocalStorage<RequestContextStore>();
+
+export function getRequestId(): string | undefined {
+    return requestContext.getStore()?.requestId;
+}


### PR DESCRIPTION
Adds a per-request correlation ID so all log lines for a single request can be traced together.

- `logging.middleware.ts` now reads the incoming `x-request-id` header if present, or generates a new UUID otherwise
- The request ID is attached to the HTTP log line (method/path/status/duration)
- The request ID is set on the response as `X-Request-ID` for client-side correlation
- Added `request-context.ts` using `AsyncLocalStorage` so the request ID is accessible from anywhere in the request lifecycle (e.g. services called from controllers), not just the middleware