### PR TITLE
Add modal/dropdown a11y fixes, pagination hook, and error boundary

### DIFF
--- a/nevo_frontend/app/dashboard/page.tsx
+++ b/nevo_frontend/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useWalletStore } from '@/src/store/walletStore';
 import { EmptyState } from '@/components/EmptyState';
@@ -328,6 +328,9 @@ function StatusBadge({ status }: { status: Pool['status'] }) {
 
 /* ── ConfirmModal ─────────────────────────────────────────────────────────── */
 
+const FOCUSABLE =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
 function ConfirmModal({
   modal,
   onClose,
@@ -338,6 +341,57 @@ function ConfirmModal({
   onConfirm: () => void;
 }) {
   const isWithdraw = modal.type === 'withdraw';
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  const handleKeyDown = useCallback(
+    (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key !== 'Tab' || !dialogRef.current) return;
+
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE)
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    triggerRef.current = document.activeElement as HTMLElement | null;
+
+    const id = requestAnimationFrame(() => {
+      const el = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE);
+      el?.focus();
+    });
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      cancelAnimationFrame(id);
+      document.removeEventListener('keydown', handleKeyDown);
+      triggerRef.current?.focus();
+    };
+  }, [handleKeyDown]);
 
   return (
     <div
@@ -353,7 +407,10 @@ function ConfirmModal({
         aria-hidden="true"
       />
 
-      <div className="relative w-full max-w-sm rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-xl">
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-sm rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-xl"
+      >
         <h2 id="modal-title" className="text-base font-semibold">
           {isWithdraw ? 'Withdraw funds' : 'Archive pool'}
         </h2>

--- a/nevo_frontend/app/pools/[id]/page.tsx
+++ b/nevo_frontend/app/pools/[id]/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { DonateModal } from '@/components/DonateModal';
 import { EmptyState } from '@/components/EmptyState';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { WalletAddress } from '@/components/WalletAddress';
 import { CopyButton } from '@/components/CopyButton';
 import { toast } from '@/components/Toast';
@@ -46,7 +47,7 @@ interface Comment {
   replies: Comment[];
 }
 
-export default function PoolDetailPage() {
+function PoolDetailPageContent() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { publicKey, initialize } = useWalletStore();
@@ -583,6 +584,14 @@ export default function PoolDetailPage() {
         />
       )}
     </main>
+  );
+}
+
+export default function PoolDetailPage() {
+  return (
+    <ErrorBoundary>
+      <PoolDetailPageContent />
+    </ErrorBoundary>
   );
 }
 

--- a/nevo_frontend/app/pools/page.tsx
+++ b/nevo_frontend/app/pools/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { EmptyState } from '@/components/EmptyState';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Pagination, PoolCard, Skeleton } from '@/components';
 import {
   usePoolsStore,
@@ -267,7 +268,7 @@ function buildDefaultFilters(pools: Pool[]): FilterState {
   };
 }
 
-export default function BrowsePoolsPage() {
+function BrowsePoolsPageContent() {
   const { pools, loading, error, fetchPools } = usePoolsStore();
   useEffect(() => {
     fetchPools();
@@ -739,6 +740,14 @@ export default function BrowsePoolsPage() {
         </section>
       </div>
     </main>
+  );
+}
+
+export default function BrowsePoolsPage() {
+  return (
+    <ErrorBoundary>
+      <BrowsePoolsPageContent />
+    </ErrorBoundary>
   );
 }
 

--- a/nevo_frontend/components/ConnectWallet.tsx
+++ b/nevo_frontend/components/ConnectWallet.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useWalletStore } from '@/src/store/walletStore';
 import { Spinner } from '@/components/Spinner';
 import { isFreighterInstalled } from '@/app/stellar-wallets-kit';
 
-const FREIGHTER_INSTALL_URL =
-  'https://www.freighter.app/';
+const FREIGHTER_INSTALL_URL = 'https://www.freighter.app/';
 
 function shortKey(key: string) {
   return `${key.slice(0, 4)}…${key.slice(-4)}`;
@@ -28,11 +27,41 @@ export default function ConnectWallet() {
   const [freighterInstalled, setFreighterInstalled] = useState<
     boolean | undefined
   >(undefined);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setFreighterInstalled(isFreighterInstalled());
     initialize();
   }, [initialize]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
 
   async function handleConnect() {
     // Guard: do not attempt the flow if the extension is missing
@@ -120,8 +149,9 @@ export default function ConnectWallet() {
   }
 
   return (
-    <div className="relative">
+    <div className="relative" ref={dropdownRef}>
       <button
+        ref={triggerRef}
         onClick={() => setOpen((o) => !o)}
         className="flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-surface-raised)] px-3 py-1.5 text-sm font-medium hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
         aria-haspopup="dialog"

--- a/nevo_frontend/components/ErrorBoundary.tsx
+++ b/nevo_frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback !== undefined) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center">
+          <h2 className="text-lg font-semibold">Something went wrong</h2>
+          <p className="text-sm text-[var(--color-text-muted)]">
+            We could not load this page. Please try refreshing.
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="rounded-full bg-brand-600 px-5 py-2 text-sm font-semibold text-white hover:bg-brand-700 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+          >
+            Refresh
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/nevo_frontend/hooks/usePaginatedPools.ts
+++ b/nevo_frontend/hooks/usePaginatedPools.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api-client';
+import type { Pool } from '@/src/store/poolsStore';
+
+export interface UsePaginatedPoolsParams {
+  creator?: string;
+  page?: number;
+  limit?: number;
+}
+
+interface PoolsPageResponse {
+  data: Pool[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface UsePaginatedPoolsResult {
+  pools: Pool[];
+  totalPages: number;
+  currentPage: number;
+  setPage: (page: number) => void;
+  loading: boolean;
+  error: string | null;
+}
+
+export function usePaginatedPools(
+  params: UsePaginatedPoolsParams = {}
+): UsePaginatedPoolsResult {
+  const { creator, page = 1, limit = 10 } = params;
+
+  const [pools, setPools] = useState<Pool[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [currentPage, setCurrentPage] = useState(page);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCurrentPage(page);
+  }, [page]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    setError(null);
+
+    apiClient
+      .get<PoolsPageResponse>('/pools', {
+        params: { creator, page: currentPage, limit },
+      })
+      .then((res) => {
+        if (cancelled) return;
+        setPools(res?.data ?? []);
+        setTotalPages(
+          res?.total ? Math.max(1, Math.ceil(res.total / limit)) : 1
+        );
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : 'Failed to load pools';
+        setError(message);
+        setPools([]);
+        setTotalPages(1);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [creator, currentPage, limit]);
+
+  return {
+    pools,
+    totalPages,
+    currentPage,
+    setPage: setCurrentPage,
+    loading,
+    error,
+  };
+}


### PR DESCRIPTION
this pr closes #802 
this pr closes #806 
this pr closes #823 
this pr closes #824 

- Dashboard ConfirmModal: focus trap, initial focus, Escape-to-close, focus return
- ConnectWallet dropdown: Escape and click-outside dismiss, matching NotificationCenter
- New usePaginatedPools hook for GET /pools with page state
- New ErrorBoundary component wrapping the pools list and detail pages