### PR TITLE
Fix broken pools page documentation link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dist/
 !Contribution.md
 !AGENTS.md
 !Agents.md
+!docs/pools-page.md
 
 # Local plans — not committed, stays on each contributor's machine
 plans/

--- a/docs/pools-page.md
+++ b/docs/pools-page.md
@@ -1,0 +1,48 @@
+# Pools Page
+
+## Overview
+
+The Pools page provides a central place for users to browse and discover donation pools on Nevo platform. It supports searching, filtering, sorting, and comparing pools and also allowing users to create new donation campaigns.
+
+## Features
+
+### Browse Pools
+
+- View all available donation pools.
+- Navigate through pools using pagination.
+
+### Search
+
+- Search pools by title, category, or creator.
+
+### Filter
+
+- Filter pools by:
+  - Goal amount
+  - Date range
+  - Status
+  - Category
+
+### Sort
+
+Pools can be sorted by:
+
+- Newest
+- Most funded
+- Closest to goal
+- Trending
+
+### Additional Actions
+
+- Compare multiple donation pools.
+- Create a new donation pool.
+- Open an individual pool for more details.
+
+## Routes
+
+| Route | Description |
+|-------|-------------|
+| `/pools` | Browse all donation pools |
+| `/pools/[id]` | View details of a specific pool |
+| `/pools/compare` | Compare donation pools |
+| `/pools/new` | Create a new donation pool |


### PR DESCRIPTION
## Summary

This PR fixes the broken documentation link in the README by adding the missing `docs/pools-page.md` file.

### Changes
- Added documentation for the Pools page.
- Documented browsing, searching, filtering, sorting, and navigation.
- Updated `.gitignore` to allow tracking `docs/pools-page.md`.

Fixes #970