### PR TITLE
feat(frontend): add shared back-to-top button to long list pages (#882)

### DIFF
--- a/nevo_frontend/app/donations/page.tsx
+++ b/nevo_frontend/app/donations/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { BackToTopButton } from '@/components';
 import { EmptyState } from '@/components/EmptyState';
 import { useDonationsStore, Donation } from '@/src/store';
 import { CopyButton } from '@/components/CopyButton';
@@ -317,6 +318,7 @@ export default function DonationsPage() {
           )}
         </>
       )}
+      <BackToTopButton />
     </main>
   );
 }

--- a/nevo_frontend/app/pools/page.tsx
+++ b/nevo_frontend/app/pools/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { EmptyState } from '@/components/EmptyState';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { Pagination, PoolCard, Skeleton } from '@/components';
+import { BackToTopButton, Pagination, PoolCard, Skeleton } from '@/components';
 import {
   usePoolsStore,
   type Pool,
@@ -745,9 +745,12 @@ function BrowsePoolsPageContent() {
 
 export default function BrowsePoolsPage() {
   return (
-    <ErrorBoundary>
-      <BrowsePoolsPageContent />
-    </ErrorBoundary>
+    <>
+      <ErrorBoundary>
+        <BrowsePoolsPageContent />
+      </ErrorBoundary>
+      <BackToTopButton />
+    </>
   );
 }
 

--- a/nevo_frontend/app/transactions/page.tsx
+++ b/nevo_frontend/app/transactions/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { BackToTopButton } from '@/components';
 import { EmptyState } from '@/components/EmptyState';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import { apiClient } from '@/lib/api-client';
@@ -513,8 +514,11 @@ function StatusBadge({ status }: { status: TxStatus }) {
 
 export default function TransactionsPage() {
   return (
-    <ProtectedRoute>
-      <TransactionsPageContent />
-    </ProtectedRoute>
+    <>
+      <ProtectedRoute>
+        <TransactionsPageContent />
+      </ProtectedRoute>
+      <BackToTopButton />
+    </>
   );
 }

--- a/nevo_frontend/components/BackToTopButton.tsx
+++ b/nevo_frontend/components/BackToTopButton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { ArrowUp } from 'lucide-react';
+
+export interface BackToTopButtonProps {
+  /** Scroll distance (px) after which the button becomes visible. Defaults to 400. */
+  threshold?: number;
+  className?: string;
+}
+
+export function BackToTopButton({
+  threshold = 400,
+  className = '',
+}: BackToTopButtonProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let ticking = false;
+
+    const checkThreshold = () => {
+      setVisible(window.scrollY > threshold);
+      ticking = false;
+    };
+
+    const handleScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(checkThreshold);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [threshold]);
+
+  const scrollToTop = useCallback(() => {
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+    });
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      className={`fixed bottom-6 right-6 z-40 flex size-11 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)] shadow-lg transition-all duration-300 hover:text-brand-600 hover:border-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 ${
+        visible
+          ? 'pointer-events-auto translate-y-0 opacity-100'
+          : 'pointer-events-none translate-y-2 opacity-0'
+      } ${className}`}
+    >
+      <ArrowUp className="size-5" strokeWidth={2.5} aria-hidden="true" />
+    </button>
+  );
+}
+
+export default BackToTopButton;

--- a/nevo_frontend/components/index.ts
+++ b/nevo_frontend/components/index.ts
@@ -1,4 +1,5 @@
 export * from './Avatar';
+export * from './BackToTopButton';
 export * from './Button';
 export * from './ConfirmDialog';
 export * from './Dropdown';


### PR DESCRIPTION
app/pools, app/transactions, and app/donations can grow long once paginated/filtered, with no way to jump back to the top after scrolling down. Adds a single shared BackToTopButton component (components/BackToTopButton.tsx) rather than three separate copies, wired into all three pages' outer wrapper so it appears regardless of which internal state (loading/error/success) the page content is in.

- Fixed floating button (bottom-right), fades/slides in once window.scrollY exceeds a threshold (default 400px, configurable via a prop), matching the existing show/hide transition pattern already used in WalletAddress.tsx's copy-confirmation toast.
- Scroll listener is rAF-throttled to avoid a state update on every scroll-event pixel.
- Click smoothly scrolls to top (window.scrollTo({ top: 0, behavior: 'smooth' })), falling back to an instant jump when the user has prefers-reduced-motion enabled.
- Excluded from the tab order and hidden from assistive tech (aria-hidden, tabIndex={-1}) while not visible, since it stays mounted (opacity/pointer-events toggle, not conditional render) for a smooth transition -- consistent with how WalletAddress.tsx's own toast is implemented.
- Styling follows this repo's CSS-variable convention (var(--color-surface), var(--color-border), var(--color-text-muted)) and lucide-react icon usage, both already established in Pagination.tsx.

Verified: npm ci --legacy-peer-deps (matching .github/workflows/ci.yml exactly, since a bare `npm install` currently fails here on an unrelated pre-existing ERESOLVE conflict between next@16.2.4 and @sentry/nextjs@^8.47.0's peer range -- not something introduced or touched by this change) + npm run build, both pass, generating all three affected routes. Also ran npx tsc --noEmit and diffed its output against a clean stash of main: identical 10 pre-existing type errors in unrelated files (none in BackToTopButton.tsx or on any line this PR actually changed) -- confirmed no regressions, not just "the build didn't complain" (Next's build step skips type validation here).

closes #882 