### PR TITLE
chore(frontend): note that #883's copy-to-clipboard already exists

### DIFF
--- a/nevo_frontend/app/profile/page.tsx
+++ b/nevo_frontend/app/profile/page.tsx
@@ -179,6 +179,8 @@ export default function ProfilePage() {
                 {isLoading ? (
                   <div className="h-5 w-40 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mx-auto" />
                 ) : (
+                  // Copy-to-clipboard for the public key is already provided
+                  // by WalletAddress itself (see #883) — don't add a second one.
                   <WalletAddress address={publicKey || ''} />
                 )}
               </div>


### PR DESCRIPTION
#883 asked to reuse WalletAddress (or its copy pattern) on the profile page's public-key display. It's already there -- WalletAddress was wired in at this exact spot by commit 2802484
("feat(frontend): add profile loading skeleton and dashboard empty state"), which already includes the copy button, clipboard write with an execCommand fallback, and the "copied to clipboard" toast.

No functional change. Added a one-line comment so a future contributor doesn't re-add a second, redundant copy affordance here, and closing the now-stale issue via this commit rather than leaving it open with no trail.

Closes #883