### PR TITLE
test(server): add e2e tests for auth/pools and sync cursor persistenc…

### DIFF
--- a/nevo_server/package-lock.json
+++ b/nevo_server/package-lock.json
@@ -46,6 +46,7 @@
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
         "source-map-support": "^0.5.21",
+        "sql.js": "^1.14.1",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
         "ts-loader": "^9.5.2",
@@ -9433,6 +9434,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/nevo_server/package.json
+++ b/nevo_server/package.json
@@ -60,6 +60,7 @@
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
+    "sql.js": "^1.14.1",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.2",

--- a/nevo_server/src/auth/nonce.entity.ts
+++ b/nevo_server/src/auth/nonce.entity.ts
@@ -22,7 +22,7 @@ export class Nonce {
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
-  @Column({ name: 'expires_at', type: 'timestamp' })
+  @Column({ name: 'expires_at', type: 'datetime' })
   expiresAt: Date;
 
   @Column({ name: 'used', type: 'boolean', default: false })

--- a/nevo_server/src/pools/pool.entity.ts
+++ b/nevo_server/src/pools/pool.entity.ts
@@ -37,7 +37,7 @@ export class Pool {
 
   @Index()
   @Column({
-    type: 'enum',
+    type: 'simple-enum',
     enum: PoolStatus,
     default: PoolStatus.Active,
   })

--- a/nevo_server/src/sync/sync.service.spec.ts
+++ b/nevo_server/src/sync/sync.service.spec.ts
@@ -10,6 +10,7 @@ describe('SyncService', () => {
   const upsertFromChain = jest.fn();
   const markCompleted = jest.fn();
   const isTxProcessed = jest.fn();
+  const syncStateRepo = { findOne: jest.fn(), save: jest.fn() };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -17,7 +18,7 @@ describe('SyncService', () => {
         SyncService,
         { provide: PoolsService, useValue: { upsertFromChain, markCompleted } },
         { provide: DonationsService, useValue: { isTxProcessed } },
-        { provide: getRepositoryToken(SyncState), useValue: { findOne: jest.fn(), save: jest.fn() } },
+        { provide: getRepositoryToken(SyncState), useValue: syncStateRepo },
       ],
     }).compile();
 
@@ -25,6 +26,8 @@ describe('SyncService', () => {
     upsertFromChain.mockReset();
     markCompleted.mockReset();
     isTxProcessed.mockReset().mockResolvedValue(false);
+    syncStateRepo.findOne.mockReset();
+    syncStateRepo.save.mockReset();
   });
 
   it('extracts contractPoolId, creatorWallet, and goal and calls upsertFromChain', async () => {
@@ -39,6 +42,66 @@ describe('SyncService', () => {
       contractPoolId: 'pool-42',
       creatorWallet: 'GABC123',
       goal: '50000',
+    });
+  });
+
+  describe('cursor persistence', () => {
+    it('getCursor returns null when no cursor has been set', () => {
+      expect(service.getCursor()).toBeNull();
+    });
+
+    it('saveCursor persists the cursor value and updates in-memory state', async () => {
+      syncStateRepo.save.mockResolvedValue({
+        key: 'horizon_cursor',
+        value: 'cursor-42',
+      });
+
+      await service.saveCursor('cursor-42');
+
+      expect(service.getCursor()).toBe('cursor-42');
+      expect(syncStateRepo.save).toHaveBeenCalledWith({
+        key: 'horizon_cursor',
+        value: 'cursor-42',
+      });
+    });
+
+    it('saveCursor overwrites a previously set cursor', async () => {
+      syncStateRepo.save.mockResolvedValue({
+        key: 'horizon_cursor',
+        value: 'cursor-first',
+      });
+      await service.saveCursor('cursor-first');
+
+      syncStateRepo.save.mockResolvedValue({
+        key: 'horizon_cursor',
+        value: 'cursor-second',
+      });
+      await service.saveCursor('cursor-second');
+
+      expect(service.getCursor()).toBe('cursor-second');
+      expect(syncStateRepo.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('onModuleInit restores the cursor from the database on startup', async () => {
+      syncStateRepo.findOne.mockResolvedValue({
+        key: 'horizon_cursor',
+        value: 'restored-cursor',
+      });
+
+      await service.onModuleInit();
+
+      expect(syncStateRepo.findOne).toHaveBeenCalledWith({
+        where: { key: 'horizon_cursor' },
+      });
+      expect(service.getCursor()).toBe('restored-cursor');
+    });
+
+    it('onModuleInit leaves cursor null when no state exists in the database', async () => {
+      syncStateRepo.findOne.mockResolvedValue(null);
+
+      await service.onModuleInit();
+
+      expect(service.getCursor()).toBeNull();
     });
   });
 
@@ -108,7 +171,10 @@ describe('SyncService', () => {
     });
 
     it('warns and skips on duplicate txHash within the same run', async () => {
-      const loggerWarnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+      const loggerWarnSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        .spyOn((service as any).logger, 'warn')
+        .mockImplementation(() => {});
       const event: HorizonContractEvent = {
         topic: ['pool_crtd', 'pool-3'],
         value: ['GDUP', '300'],
@@ -118,7 +184,9 @@ describe('SyncService', () => {
       await service.processPoolCreatedEvent(event);
       await service.processPoolCreatedEvent(event);
 
-      expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('dup-hash'));
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dup-hash'),
+      );
       expect(upsertFromChain).toHaveBeenCalledTimes(1);
     });
 

--- a/nevo_server/test/app.e2e-spec.ts
+++ b/nevo_server/test/app.e2e-spec.ts
@@ -1,29 +1,272 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import {
+  INestApplication,
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+} from '@nestjs/common';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { APP_FILTER } from '@nestjs/core';
+import { Repository } from 'typeorm';
 import request from 'supertest';
 import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import * as StellarSdk from '@stellar/stellar-sdk';
 
-describe('AppController (e2e)', () => {
+import { AppController } from './../src/app.controller';
+import { AppService } from './../src/app.service';
+import { Pool, PoolStatus } from './../src/pools/pool.entity';
+import { User } from './../src/users/user.entity';
+import { Donation } from './../src/donations/donation.entity';
+import { SyncState } from './../src/sync/sync-state.entity';
+import { Nonce } from './../src/auth/nonce.entity';
+import { GlobalExceptionFilter } from './../src/common/global-exception.filter';
+import { LoggingMiddleware } from './../src/common/logging.middleware';
+
+import { AuthModule } from './../src/auth/auth.module';
+import { PoolsModule } from './../src/pools/pools.module';
+import { DonationsModule } from './../src/donations/donations.module';
+import { UsersModule } from './../src/users/users.module';
+import { ContractModule } from './../src/contract/contract.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'sqljs',
+      entities: [User, Pool, Donation, SyncState, Nonce],
+      synchronize: true,
+      dropSchema: true,
+    }),
+    AuthModule,
+    PoolsModule,
+    DonationsModule,
+    UsersModule,
+    ContractModule,
+  ],
+  controllers: [AppController],
+  providers: [
+    AppService,
+    {
+      provide: APP_FILTER,
+      useClass: GlobalExceptionFilter,
+    },
+  ],
+})
+class TestAppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(LoggingMiddleware).forRoutes('*');
+  }
+}
+
+describe('App (e2e)', () => {
   let app: INestApplication<App>;
+  let poolRepo: Repository<Pool>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [TestAppModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
+
+    poolRepo = moduleFixture.get<Repository<Pool>>(getRepositoryToken(Pool));
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
-  });
-
-  afterEach(async () => {
+  afterAll(async () => {
     await app.close();
+  });
+
+  describe('Auth — challenge/verify flow', () => {
+    const keypair = StellarSdk.Keypair.random();
+    const publicKey = keypair.publicKey();
+
+    it('GET /auth/challenge returns a nonce for a valid public key', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/auth/challenge')
+        .query({ publicKey })
+        .expect(200);
+
+      const body = res.body as { nonce: string };
+      expect(body).toHaveProperty('nonce');
+      expect(typeof body.nonce).toBe('string');
+      expect(body.nonce.length).toBeGreaterThan(0);
+    });
+
+    it('GET /auth/challenge without publicKey returns 400', async () => {
+      await request(app.getHttpServer()).get('/auth/challenge').expect(400);
+    });
+
+    it('POST /auth/verify with a valid Stellar signature returns accessToken and user', async () => {
+      const challengeRes = await request(app.getHttpServer())
+        .get('/auth/challenge')
+        .query({ publicKey })
+        .expect(200);
+
+      const nonce = (challengeRes.body as { nonce: string }).nonce;
+      const signature = keypair.sign(Buffer.from(nonce)).toString('hex');
+
+      const verifyRes = await request(app.getHttpServer())
+        .post('/auth/verify')
+        .send({ publicKey, signature, message: nonce })
+        .expect(201);
+
+      const body = verifyRes.body as {
+        accessToken: string;
+        user: Record<string, unknown>;
+      };
+      expect(body).toHaveProperty('accessToken');
+      expect(typeof body.accessToken).toBe('string');
+      expect(body).toHaveProperty('user');
+      expect(body.user).toMatchObject({
+        publicKey,
+      });
+    });
+
+    it('POST /auth/verify with an invalid signature returns 401', async () => {
+      const challengeRes = await request(app.getHttpServer())
+        .get('/auth/challenge')
+        .query({ publicKey })
+        .expect(200);
+
+      const nonce = (challengeRes.body as { nonce: string }).nonce;
+      const badSignature = '00'.repeat(64);
+
+      await request(app.getHttpServer())
+        .post('/auth/verify')
+        .send({ publicKey, signature: badSignature, message: nonce })
+        .expect(401);
+    });
+
+    it('POST /auth/verify with the same nonce twice returns 401 on second call', async () => {
+      const challengeRes = await request(app.getHttpServer())
+        .get('/auth/challenge')
+        .query({ publicKey })
+        .expect(200);
+
+      const nonce = (challengeRes.body as { nonce: string }).nonce;
+      const signature = keypair.sign(Buffer.from(nonce)).toString('hex');
+
+      await request(app.getHttpServer())
+        .post('/auth/verify')
+        .send({ publicKey, signature, message: nonce })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/auth/verify')
+        .send({ publicKey, signature, message: nonce })
+        .expect(401);
+    });
+  });
+
+  describe('Pools — seeded data', () => {
+    beforeEach(async () => {
+      await poolRepo.clear();
+      await poolRepo.save([
+        poolRepo.create({
+          contractPoolId: '42',
+          creatorWallet: 'GABC1234567890123456789012345678901234567',
+          goal: '100000',
+          title: 'Community Garden',
+          description: 'Building a community garden in the park',
+          category: 'Environment',
+          status: PoolStatus.Active,
+          raised: '25000',
+          imageUrl: null,
+        }),
+        poolRepo.create({
+          contractPoolId: '99',
+          creatorWallet: 'GDEF9876543210987654321098765432109876543',
+          goal: '50000',
+          title: 'School Supplies',
+          description: 'School supplies for underprivileged children',
+          category: 'Education',
+          status: PoolStatus.Active,
+          raised: '0',
+          imageUrl: null,
+        }),
+        poolRepo.create({
+          contractPoolId: '7',
+          creatorWallet: 'GXYZ1111111111111111111111111111111111111',
+          goal: '200000',
+          title: 'Animal Shelter',
+          description: 'New roof for the animal shelter',
+          category: 'Animals',
+          status: PoolStatus.Completed,
+          raised: '200000',
+          imageUrl: null,
+        }),
+      ]);
+    });
+
+    it('GET /pools returns all seeded pools with pagination', async () => {
+      const res = await request(app.getHttpServer()).get('/pools').expect(200);
+
+      const body = res.body as {
+        data: unknown[];
+        total: number;
+        page: number;
+        limit: number;
+      };
+      expect(body).toHaveProperty('data');
+      expect(body).toHaveProperty('total');
+      expect(body).toHaveProperty('page');
+      expect(body).toHaveProperty('limit');
+      expect(body.total).toBe(3);
+      expect(body.data).toHaveLength(3);
+    });
+
+    it('GET /pools filters by status', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/pools')
+        .query({ status: 'active' })
+        .expect(200);
+
+      const body = res.body as { total: number; data: Pool[] };
+      expect(body.total).toBe(2);
+      expect(body.data.every((p: Pool) => p.status === PoolStatus.Active)).toBe(
+        true,
+      );
+    });
+
+    it('GET /pools filters by category', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/pools')
+        .query({ category: 'Education' })
+        .expect(200);
+
+      const body = res.body as { total: number; data: Pool[] };
+      expect(body.total).toBe(1);
+      expect(body.data[0].title).toBe('School Supplies');
+    });
+
+    it('GET /pools searches by title or description', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/pools')
+        .query({ search: 'garden' })
+        .expect(200);
+
+      const body = res.body as { total: number; data: Pool[] };
+      expect(body.total).toBe(1);
+      expect(body.data[0].title).toBe('Community Garden');
+    });
+
+    it('GET /pools/:id returns a single pool', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/pools/42')
+        .expect(200);
+
+      const body = res.body as {
+        contractPoolId: string;
+        title: string;
+        creatorWallet: string;
+      };
+      expect(body).toMatchObject({
+        contractPoolId: '42',
+        title: 'Community Garden',
+        creatorWallet: 'GABC1234567890123456789012345678901234567',
+      });
+    });
   });
 });

--- a/nevo_server/test/jest-e2e.json
+++ b/nevo_server/test/jest-e2e.json
@@ -4,6 +4,20 @@
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      {
+        "useESM": true
+      }
+    ]
+  },
+  "extensionsToTreatAsEsm": [
+    ".ts"
+  ],
+  "transformIgnorePatterns": [
+    "/node_modules/(?!(@stellar/stellar-sdk|@noble/.*|uint8array-extras)/)"
+  ],
+  "moduleNameMapper": {
+    "^(\\.\\.?/.*)\\.js$": "$1"
   }
 }


### PR DESCRIPTION
…e tests

- Add 10 e2e tests covering auth challenge/verify flow and GET /pools with seeded data using sql.js in-memory database
- Add 5 cursor persistence tests for getCursor, saveCursor, onModuleInit
- Add jest-e2e.json ESM support for @stellar/stellar-sdk imports
- Change pool.entity status column: enum → simple-enum (sqljs compat)
- Change nonce.entity expiresAt column: timestamp → datetime (sqljs compat)

Closes #896
closes #897