### PR TITLE
fix(frontend): document stroop units and replace mock receipt fallback

### DIFF
--- a/nevo_frontend/app/donations/receipt/page.tsx
+++ b/nevo_frontend/app/donations/receipt/page.tsx
@@ -1,40 +1,53 @@
 'use client';
 
-import React, { useEffect, useState, Suspense } from 'react';
+import React, { useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useDonationsStore } from '@/src/store/donationsStore';
-import type { Donation } from '@/src/store/donationsStore';
+import { EmptyState } from '@/components/EmptyState';
 
 function ReceiptContent() {
   const searchParams = useSearchParams();
   const txHashParam = searchParams.get('txHash');
   const router = useRouter();
   const { history } = useDonationsStore();
-  const [donation, setDonation] = useState<Donation | null>(null);
+
+  const donation = txHashParam
+    ? (history.find((d) => d.txHash === txHashParam) ?? null)
+    : null;
+  const notFound = !!txHashParam && donation === null;
 
   useEffect(() => {
     if (!txHashParam) {
       router.replace('/');
-      return;
     }
-    const found = history.find((d) => d.txHash === txHashParam);
-    if (!found) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setDonation({
-        id: 'mock-id',
-        poolId: '1',
-        poolName: 'Unknown Pool',
-        amount: '0',
-        asset: 'XLM',
-        txHash: txHashParam,
-        timestamp: new Date().toISOString(),
-        status: 'confirmed',
-      });
-    } else {
-      setDonation(found);
-    }
-  }, [txHashParam, history, router]);
+  }, [txHashParam, router]);
+
+  if (!txHashParam) {
+    return (
+      <div className="flex justify-center py-20">
+        <div className="size-8 animate-spin rounded-full border-4 border-[var(--color-border)] border-t-brand-600" />
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-12 sm:px-6">
+        <EmptyState
+          icon="not-found"
+          title="Receipt not found"
+          description="We couldn't find a donation receipt matching this transaction. It may have been made in a different browser or device."
+          action={{ label: 'Go to home', href: '/' }}
+          secondaryAction={{
+            label: 'View donation history',
+            href: '/donations',
+            variant: 'secondary',
+          }}
+        />
+      </main>
+    );
+  }
 
   if (!donation) {
     return (

--- a/nevo_frontend/lib/contract-service.ts
+++ b/nevo_frontend/lib/contract-service.ts
@@ -55,6 +55,11 @@ class ContractService {
     }
   }
 
+  /**
+   * Builds an XDR-encoded transaction to create a new donation pool.
+   *
+   * @param goal - Fundraising goal in stroops (1 XLM = 10,000,000 stroops).
+   */
   async buildCreatePoolTransaction(
     creator: string,
     title: string,
@@ -83,6 +88,11 @@ class ContractService {
     return prepared.toXDR();
   }
 
+  /**
+   * Builds an XDR-encoded transaction to donate to a pool.
+   *
+   * @param amount - Donation amount in stroops (1 XLM = 10,000,000 stroops).
+   */
   async buildDonateTransaction(
     poolId: number,
     donor: string,
@@ -109,6 +119,7 @@ class ContractService {
     return prepared.toXDR();
   }
 
+  /** Builds an XDR-encoded transaction to withdraw unallocated funds from a pool. */
   async buildWithdrawTransaction(
     poolId: number,
     creator: string,
@@ -134,6 +145,7 @@ class ContractService {
     return prepared.toXDR();
   }
 
+  /** Builds an XDR-encoded transaction to close a pool permanently. */
   async buildClosePoolTransaction(
     poolId: number,
     creator: string


### PR DESCRIPTION
## Summary

Fixes two P2 frontend issues in a single focused PR.

---

### #851 — Document stroop units in `lib/contract-service.ts`

Added JSDoc comments to all four transaction-builder methods:

- `buildCreatePoolTransaction` — documents that `goal` is in stroops
- `buildDonateTransaction` — documents that `amount` is in stroops
- `buildWithdrawTransaction` — general description (no amount param)
- `buildClosePoolTransaction` — general description (no amount param)

This prevents new contributors from introducing an off-by-10,000,000 bug by passing XLM values instead of stroops (1 XLM = 10,000,000 stroops).

---

### #856 — Replace fabricated fallback donation on the receipt page

Removed the hardcoded mock `Donation` object (`id: 'mock-id'`, `poolName: 'Unknown Pool'`, `amount: '0'`) that was fabricated when a `txHash` was not found in the local donation history store.

The page now:
1. Derives `donation` and `notFound` directly from the store (no `setState` in effect — satisfies the `react-hooks/set-state-in-effect` lint rule).
2. Renders the shared `EmptyState` component (`icon='not-found'`) with a clear "Receipt not found" title, a helpful description, and actions to navigate home or to donation history.

---

## Testing

- `npm run build` passes (pre-commit ESLint/Prettier + pre-push build hook both green).
- All pre-existing warnings are from `sodium-native` dynamic requires inside `@stellar/stellar-sdk` — unrelated to this PR.

---

Closes #851
Closes #856