### PR TITLE
docs(frontend): add JSDoc, ProtectedRoute tests, rate-limit/errors docs

### DIFF
--- a/nevo_frontend/__tests__/ProtectedRoute.test.tsx
+++ b/nevo_frontend/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ProtectedRoute from '../components/ProtectedRoute';
+import { useWalletStore } from '@/src/store/walletStore';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/dashboard',
+}));
+
+jest.mock('@/src/store/walletStore', () => ({
+  useWalletStore: jest.fn(),
+}));
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects unauthenticated users to /login with a from query param', () => {
+    (useWalletStore as unknown as jest.Mock).mockReturnValue({
+      isAuthenticated: false,
+      loading: false,
+      initialize: jest.fn(),
+    });
+
+    render(
+      <ProtectedRoute>
+        <div data-testid="protected-content">Secret</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+    expect(mockPush).toHaveBeenCalledWith('/login?from=%2Fdashboard');
+  });
+
+  it('renders children when the user is authenticated', () => {
+    (useWalletStore as unknown as jest.Mock).mockReturnValue({
+      isAuthenticated: true,
+      loading: false,
+      initialize: jest.fn(),
+    });
+
+    render(
+      <ProtectedRoute>
+        <div data-testid="protected-content">Secret</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading indicator and does not redirect while loading', () => {
+    (useWalletStore as unknown as jest.Mock).mockReturnValue({
+      isAuthenticated: false,
+      loading: true,
+      initialize: jest.fn(),
+    });
+
+    render(
+      <ProtectedRoute>
+        <div data-testid="protected-content">Secret</div>
+      </ProtectedRoute>
+    );
+
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/nevo_frontend/lib/errors.ts
+++ b/nevo_frontend/lib/errors.ts
@@ -45,6 +45,19 @@ function extractFromPayload(payload: unknown): string | undefined {
   return extractString(record.message) ?? extractString(record.error);
 }
 
+/**
+ * Extracts a human-readable message from an error of unknown shape.
+ *
+ * **Precedence order** (first match wins):
+ * 1. Axios-shaped error (`err.response.data.message` or `.error`)
+ * 2. `ApiError` instance (`err.data.message` or `.error`)
+ * 3. Standard `Error` instance (`err.message`)
+ * 4. Generic object with a `message` property
+ * 5. Fallback string: `"Something went wrong. Please try again."`
+ *
+ * This order ensures server-provided messages are preferred over generic stack
+ * traces, and structured API errors are preferred over plain `Error` objects.
+ */
 export function parseApiError(err: unknown): string {
   if (isAxiosError(err)) {
     const fromResponse = extractFromPayload(err.response?.data);

--- a/nevo_frontend/lib/rate-limit.ts
+++ b/nevo_frontend/lib/rate-limit.ts
@@ -23,6 +23,11 @@ export interface RateLimitNotification {
   endpoint?: string;
 }
 
+/**
+ * Custom DOM event name dispatched when the HTTP client hits a rate limit.
+ * Subscribe with:
+ * `window.addEventListener(RATE_LIMIT_EVENT, (e: CustomEvent<RateLimitNotification>) => { ... })`
+ */
 export const RATE_LIMIT_EVENT = 'nevo:api-rate-limit';
 
 const DEFAULT_MAX_REQUESTS = 30;
@@ -48,6 +53,10 @@ export const DEFAULT_RATE_LIMIT_OPTIONS: RateLimitOptions = {
   ),
 };
 
+/**
+ * Merges partial rate-limit options with sensible defaults. Non-positive or
+ * missing values fall back to `DEFAULT_RATE_LIMIT_OPTIONS`.
+ */
 export function resolveRateLimitOptions(
   options: Partial<RateLimitOptions> = {}
 ): RateLimitOptions {
@@ -124,6 +133,10 @@ export function parseRetryAfterHeader(
   return null;
 }
 
+/**
+ * Dispatches `RATE_LIMIT_EVENT` on `window` so UI layers (notifications,
+ * toasts) can react to rate-limit errors without importing the API client.
+ */
 export function notifyRateLimit(error: RateLimitError): void {
   if (typeof window === 'undefined') return;
 
@@ -138,6 +151,11 @@ export function notifyRateLimit(error: RateLimitError): void {
   window.dispatchEvent(new CustomEvent(RATE_LIMIT_EVENT, { detail }));
 }
 
+/**
+ * In-memory sliding-window rate limiter keyed by arbitrary strings (e.g.
+ * endpoint paths). Used by the API client to enforce per-endpoint limits
+ * before requests are sent.
+ */
 export class ClientRateLimiter {
   private windows = new Map<string, WindowCounter>();
 

--- a/nevo_frontend/lib/validation.ts
+++ b/nevo_frontend/lib/validation.ts
@@ -3,6 +3,14 @@ export type ValidationRule<T = unknown> = {
   message: string;
 };
 
+/**
+ * Runs an array of validation rules against a value in order, returning the
+ * first error message encountered or `null` if all rules pass.
+ *
+ * @param value  The value to validate.
+ * @param rules  Validation rules to apply in order.
+ * @returns The first error message, or `null` if all rules pass.
+ */
 export const runValidation = async <T>(
   value: T,
   rules: ValidationRule<T>[]
@@ -16,6 +24,10 @@ export const runValidation = async <T>(
   return null;
 };
 
+/**
+ * Creates a rule that rejects `null`, `undefined`, empty strings, and empty arrays.
+ * Returns the validation rule object.
+ */
 export const isRequired = (
   message = 'This field is required'
 ): ValidationRule => ({
@@ -28,6 +40,10 @@ export const isRequired = (
   message,
 });
 
+/**
+ * Creates a rule that validates a string against a basic email pattern.
+ * Returns the validation rule object.
+ */
 export const isEmail = (
   message = 'Invalid email format'
 ): ValidationRule<string> => ({
@@ -39,6 +55,10 @@ export const isEmail = (
   message,
 });
 
+/**
+ * Creates a rule that validates a string as a phone number (digits, dashes,
+ * spaces, optional leading `+`). Returns the validation rule object.
+ */
 export const isPhone = (
   message = 'Invalid phone number format'
 ): ValidationRule<string> => ({
@@ -50,6 +70,10 @@ export const isPhone = (
   message,
 });
 
+/**
+ * Creates a rule that validates a string as a well-formed URL using `new URL()`.
+ * Returns the validation rule object.
+ */
 export const isUrl = (
   message = 'Invalid URL format'
 ): ValidationRule<string> => ({
@@ -65,6 +89,11 @@ export const isUrl = (
   message,
 });
 
+/**
+ * Creates a rule that validates a string or number as a positive decimal with
+ * up to two fractional digits (e.g. `"19.99"`, `100`).
+ * Returns the validation rule object.
+ */
 export const isCurrencyAmount = (
   message = 'Invalid currency amount'
 ): ValidationRule<string | number> => ({
@@ -77,6 +106,10 @@ export const isCurrencyAmount = (
   message,
 });
 
+/**
+ * Creates a rule that rejects strings shorter than `min` characters.
+ * Returns the validation rule object.
+ */
 export const minLength = (
   min: number,
   message?: string
@@ -88,6 +121,10 @@ export const minLength = (
   message: message || `Minimum length is ${min} characters`,
 });
 
+/**
+ * Creates a rule that rejects strings longer than `max` characters.
+ * Returns the validation rule object.
+ */
 export const maxLength = (
   max: number,
   message?: string


### PR DESCRIPTION
Closes #845 
Closes #848 
Closes #849
Closes #850 


Four documentation and testing improvements: (1) JSDoc comments for validation helpers, (2) unit tests for ProtectedRoute component, (3) doc comments for rate-limit exports, (4) precedence docs for parseApiError. Build passes and all new tests pass.