### PR TITLE
test: add unit tests for Toast, ConfirmDialog, notificationsStore, and themeStore

### DIFF
--- a/nevo_frontend/__tests__/ConfirmDialog.test.tsx
+++ b/nevo_frontend/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    title: 'Delete Item',
+    message: 'Are you sure?',
+    onConfirm: jest.fn(),
+    onCancel: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Properly mock showModal and close to update the open state
+    HTMLDialogElement.prototype.showModal = jest.fn(function (
+      this: HTMLDialogElement
+    ) {
+      this.open = true;
+    });
+    HTMLDialogElement.prototype.close = jest.fn(function (
+      this: HTMLDialogElement
+    ) {
+      this.open = false;
+    });
+  });
+
+  it('renders title and message', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByText('Delete Item')).toBeInTheDocument();
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+  });
+
+  it('calls showModal when open is true', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+
+  it('calls close when open transitions to false', () => {
+    const { rerender } = render(
+      <ConfirmDialog {...defaultProps} open={false} />
+    );
+    rerender(<ConfirmDialog {...defaultProps} open={true} />);
+    rerender(<ConfirmDialog {...defaultProps} open={false} />);
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it('calls onConfirm when confirm button clicked', async () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    await userEvent.click(screen.getByText('Confirm'));
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel button clicked', async () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    await userEvent.click(screen.getByText('Cancel'));
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel on Escape keypress', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    const dialog = document.querySelector('dialog')!;
+    fireEvent(dialog, new Event('cancel', { cancelable: true }));
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel on backdrop click', () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    const dialog = document.querySelector('dialog')!;
+    fireEvent.click(dialog);
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses custom confirm and cancel labels', () => {
+    render(
+      <ConfirmDialog {...defaultProps} confirmLabel="Yes" cancelLabel="No" />
+    );
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+  });
+
+  it('renders danger variant icon', () => {
+    render(<ConfirmDialog {...defaultProps} variant="danger" />);
+    expect(document.querySelector('dialog')).toBeInTheDocument();
+  });
+
+  it('renders primary variant icon', () => {
+    render(<ConfirmDialog {...defaultProps} variant="primary" />);
+    expect(document.querySelector('dialog')).toBeInTheDocument();
+  });
+
+  it('disables buttons when loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading={true} />);
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('does not call onConfirm when loading', async () => {
+    render(<ConfirmDialog {...defaultProps} loading={true} />);
+    await userEvent.click(screen.getByText('Confirm'));
+    expect(defaultProps.onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/nevo_frontend/__tests__/Toast.test.tsx
+++ b/nevo_frontend/__tests__/Toast.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast, ToastContainer } from '@/components/Toast';
+
+describe('Toast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders a toast when toast() is called', () => {
+    render(<ToastContainer />);
+    act(() => {
+      toast('Hello world');
+    });
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('queues multiple toasts', () => {
+    render(<ToastContainer />);
+    act(() => {
+      toast('First');
+      toast('Second');
+      toast('Third');
+    });
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+    expect(screen.getByText('Third')).toBeInTheDocument();
+  });
+
+  it('auto-dismisses a toast after 3000ms', () => {
+    render(<ToastContainer />);
+    act(() => {
+      toast('Auto dismiss');
+    });
+    expect(screen.getByText('Auto dismiss')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(screen.queryByText('Auto dismiss')).not.toBeInTheDocument();
+  });
+
+  it('dismisses on close button click', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<ToastContainer />);
+    act(() => {
+      toast('Dismiss me');
+    });
+    await user.click(screen.getByLabelText('Dismiss notification'));
+    expect(screen.queryByText('Dismiss me')).not.toBeInTheDocument();
+  });
+
+  it('renders success type with green background', () => {
+    render(<ToastContainer />);
+    act(() => {
+      toast('Success', 'success');
+    });
+    const el = screen.getByRole('status');
+    expect(el).toHaveClass('bg-green-600');
+  });
+
+  it('renders error type with red background', () => {
+    render(<ToastContainer />);
+    act(() => {
+      toast('Error', 'error');
+    });
+    const el = screen.getByRole('status');
+    expect(el).toHaveClass('bg-red-600');
+  });
+
+  it('renders info type with blue background', () => {
+    render(<ToastContainer />);
+    act(() => {
+      toast('Info', 'info');
+    });
+    const el = screen.getByRole('status');
+    expect(el).toHaveClass('bg-blue-600');
+  });
+
+  it('defaults to success type when not specified', () => {
+    render(<ToastContainer />);
+    act(() => {
+      toast('Default');
+    });
+    const el = screen.getByRole('status');
+    expect(el).toHaveClass('bg-green-600');
+  });
+
+  it('returns null when no toasts are present', () => {
+    const { container } = render(<ToastContainer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not throw when toast() called before ToastContainer mounts', () => {
+    expect(() => toast('early')).not.toThrow();
+  });
+
+  it('cleans up addToastFn on unmount', () => {
+    const { unmount } = render(<ToastContainer />);
+    unmount();
+    expect(() => toast('After unmount')).not.toThrow();
+  });
+});

--- a/nevo_frontend/jest.config.ts
+++ b/nevo_frontend/jest.config.ts
@@ -9,7 +9,11 @@ const config: Config = {
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: { jsx: 'react-jsx' } }],
   },
-  testMatch: ['**/__tests__/**/*.test.{ts,tsx}', '**/hooks/**/*.test.{ts,tsx}'],
+  testMatch: [
+    '**/__tests__/**/*.test.{ts,tsx}',
+    '**/hooks/**/*.test.{ts,tsx}',
+    '**/src/store/**/*.test.{ts,tsx}',
+  ],
 };
 
 export default config;

--- a/nevo_frontend/src/store/notificationsStore.test.ts
+++ b/nevo_frontend/src/store/notificationsStore.test.ts
@@ -1,0 +1,143 @@
+import { useNotificationsStore } from '@/src/store/notificationsStore';
+
+const baseNotification = {
+  type: 'donation' as const,
+  title: 'New Donation',
+  message: 'Someone donated 10 XLM',
+  link: '/pools/123',
+};
+
+beforeEach(() => useNotificationsStore.setState({ notifications: [] }));
+
+describe('notificationsStore', () => {
+  describe('addNotification', () => {
+    it('adds a notification to the store', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      expect(useNotificationsStore.getState().notifications).toHaveLength(1);
+    });
+
+    it('prepends new notifications', () => {
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'First',
+      });
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'Second',
+      });
+      const { notifications } = useNotificationsStore.getState();
+      expect(notifications[0].title).toBe('Second');
+      expect(notifications[1].title).toBe('First');
+    });
+
+    it('sets isRead to false', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      const { notifications } = useNotificationsStore.getState();
+      expect(notifications[0].isRead).toBe(false);
+    });
+
+    it('generates an id', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      const { notifications } = useNotificationsStore.getState();
+      expect(notifications[0].id).toBeDefined();
+      expect(notifications[0].id).toMatch(/^notif-/);
+    });
+
+    it('sets a timestamp', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      const { notifications } = useNotificationsStore.getState();
+      expect(notifications[0].timestamp).toBeDefined();
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('marks a single notification as read', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      const { id } = useNotificationsStore.getState().notifications[0];
+      useNotificationsStore.getState().markAsRead(id);
+      expect(useNotificationsStore.getState().notifications[0].isRead).toBe(
+        true
+      );
+    });
+
+    it('does not affect other notifications', () => {
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'A',
+      });
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'B',
+      });
+      const [b, a] = useNotificationsStore.getState().notifications;
+      useNotificationsStore.getState().markAsRead(a.id);
+      const state = useNotificationsStore.getState().notifications;
+      const updatedA = state.find((n) => n.id === a.id);
+      const updatedB = state.find((n) => n.id === b.id);
+      expect(updatedA!.isRead).toBe(true);
+      expect(updatedB!.isRead).toBe(false);
+    });
+  });
+
+  describe('markAllAsRead', () => {
+    it('marks all notifications as read', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'Another',
+      });
+      useNotificationsStore.getState().markAllAsRead();
+      const { notifications } = useNotificationsStore.getState();
+      expect(notifications).toHaveLength(2);
+      notifications.forEach((n) => expect(n.isRead).toBe(true));
+    });
+
+    it('does nothing on empty list', () => {
+      expect(() =>
+        useNotificationsStore.getState().markAllAsRead()
+      ).not.toThrow();
+      expect(useNotificationsStore.getState().notifications).toHaveLength(0);
+    });
+  });
+
+  describe('deleteNotification', () => {
+    it('removes a notification by id', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      const { id } = useNotificationsStore.getState().notifications[0];
+      useNotificationsStore.getState().deleteNotification(id);
+      expect(useNotificationsStore.getState().notifications).toHaveLength(0);
+    });
+
+    it('removes only the targeted notification', () => {
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'Keep',
+      });
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'Remove',
+      });
+      const { id } = useNotificationsStore.getState().notifications[0]; // newest first = 'Remove'
+      useNotificationsStore.getState().deleteNotification(id);
+      const { notifications } = useNotificationsStore.getState();
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].title).toBe('Keep');
+    });
+  });
+
+  describe('clearAll', () => {
+    it('removes all notifications', () => {
+      useNotificationsStore.getState().addNotification(baseNotification);
+      useNotificationsStore.getState().addNotification({
+        ...baseNotification,
+        title: 'Second',
+      });
+      useNotificationsStore.getState().clearAll();
+      expect(useNotificationsStore.getState().notifications).toHaveLength(0);
+    });
+
+    it('works on already empty store', () => {
+      expect(() => useNotificationsStore.getState().clearAll()).not.toThrow();
+    });
+  });
+});

--- a/nevo_frontend/src/store/themeStore.test.ts
+++ b/nevo_frontend/src/store/themeStore.test.ts
@@ -1,0 +1,71 @@
+import { useThemeStore } from '@/src/store/themeStore';
+
+beforeEach(() => {
+  const root = document.documentElement;
+  root.classList.remove('dark');
+  localStorage.clear();
+  useThemeStore.setState({ theme: 'light' });
+});
+
+describe('themeStore', () => {
+  describe('setTheme', () => {
+    it('sets theme to dark in state', () => {
+      useThemeStore.getState().setTheme('dark');
+      expect(useThemeStore.getState().theme).toBe('dark');
+    });
+
+    it('adds dark class to documentElement when set to dark', () => {
+      useThemeStore.getState().setTheme('dark');
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('removes dark class from documentElement when set to light', () => {
+      document.documentElement.classList.add('dark');
+      useThemeStore.getState().setTheme('light');
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('persists theme to localStorage', () => {
+      useThemeStore.getState().setTheme('dark');
+      expect(localStorage.getItem('nevo-theme')).toBe('dark');
+    });
+
+    it('persists light theme to localStorage', () => {
+      useThemeStore.getState().setTheme('light');
+      expect(localStorage.getItem('nevo-theme')).toBe('light');
+    });
+  });
+
+  describe('toggleTheme', () => {
+    it('toggles from light to dark', () => {
+      useThemeStore.setState({ theme: 'light' });
+      useThemeStore.getState().toggleTheme();
+      expect(useThemeStore.getState().theme).toBe('dark');
+    });
+
+    it('toggles from dark to light', () => {
+      useThemeStore.setState({ theme: 'dark' });
+      useThemeStore.getState().toggleTheme();
+      expect(useThemeStore.getState().theme).toBe('light');
+    });
+
+    it('adds dark class when toggling to dark', () => {
+      useThemeStore.setState({ theme: 'light' });
+      useThemeStore.getState().toggleTheme();
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('removes dark class when toggling to light', () => {
+      useThemeStore.setState({ theme: 'dark' });
+      document.documentElement.classList.add('dark');
+      useThemeStore.getState().toggleTheme();
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('updates localStorage on toggle', () => {
+      useThemeStore.setState({ theme: 'light' });
+      useThemeStore.getState().toggleTheme();
+      expect(localStorage.getItem('nevo-theme')).toBe('dark');
+    });
+  });
+});


### PR DESCRIPTION
Closes #840
Closes #841
Closes #843
Closes #844

## Summary

Adds missing unit test coverage for 4 components/stores that previously had no tests.

### What's Included

#### 1. `components/Toast.test.tsx`
Covers the module-level `toast()` singleton function and `ToastContainer` component:
- Single toast rendering when `toast()` is called
- Multiple toasts queuing/stacking correctly
- Auto-dismiss after 3000ms timeout (using fake timers)
- Manual dismiss via close button click
- Type variants: success (green), error (red), info (blue)
- Default type when not specified
- Empty state (returns null)
- Graceful handling when `toast()` called before mount or after unmount

#### 2. `components/ConfirmDialog.test.tsx`
Covers the native `<dialog>` element behavior:
- Dialog opens via `open` prop (calls `showModal`)
- Dialog closes when `open` transitions to `false` (calls `close`)
- Confirm button calls `onConfirm`
- Cancel button calls `onCancel`
- Escape key triggers `onCancel` via native `cancel` event
- Backdrop click triggers `onCancel`
- Custom confirm/cancel labels
- Danger and primary variants render correctly
- Loading state disables all buttons and prevents confirm

#### 3. `src/store/notificationsStore.test.ts`
Covers the four store actions:
- `addNotification` — prepends to state, generates `id`, sets `isRead: false`, sets timestamp
- `markAsRead` — marks single notification as read, doesn't affect others
- `markAllAsRead` — marks all read, handles empty list
- `deleteNotification` — removes by id, removes only the targeted one
- `clearAll` — removes all notifications, handles empty store

#### 4. `src/store/themeStore.test.ts`
Covers theme management with DOM side effects:
- `setTheme('dark')` — updates store state, adds `dark` class to `document.documentElement`, persists to `localStorage`
- `setTheme('light')` — removes `dark` class, persists to `localStorage`
- `toggleTheme` — flips between light/dark, updates classList and localStorage accordingly

Also updated `jest.config.ts` to include `**/src/store/**/*.test.{ts,tsx}` in `testMatch`.

### Verification

- All 46 tests pass (`npx jest`)
- Build passes (`npm run build`)
