### PR TITLE
chore: add root .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,jsx,ts,tsx,mjs,cjs,json,yml,yaml,css,scss,html}]
+indent_style = space
+indent_size = 2
+
+[*.{rs,toml}]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
Adds a root `.editorconfig` so editors share charset/EOL/indent defaults across TypeScript layers (2-space, matching Prettier) and Rust/TOML (4-space).

Fixes #971

## Test plan
- [x] File-only change
- [ ] Open a `.ts` and `.rs` file in an EditorConfig-aware editor and confirm indent hints