### PR TITLE
Feat/add unit tests coverage

### DIFF
--- a/nevo_frontend/__tests__/Pagination.test.tsx
+++ b/nevo_frontend/__tests__/Pagination.test.tsx
@@ -1,0 +1,254 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Pagination } from '../components/Pagination';
+
+describe('Pagination', () => {
+  describe('page-range rendering with ellipses', () => {
+    it('renders all pages without ellipses when total pages <= maxVisiblePages', () => {
+      render(<Pagination totalItems={50} itemsPerPage={10} />);
+
+      // totalPages = 5, maxVisiblePages default = 7 → no ellipses
+      expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
+      expect(screen.getByLabelText('Page 2')).toBeInTheDocument();
+      expect(screen.getByLabelText('Page 3')).toBeInTheDocument();
+      expect(screen.getByLabelText('Page 4')).toBeInTheDocument();
+      expect(screen.getByLabelText('Page 5')).toBeInTheDocument();
+
+      // No ellipsis elements
+      const ellipses = screen.queryAllByText('…');
+      expect(ellipses.length).toBe(0);
+    });
+
+    it('renders ellipses when total pages is large', () => {
+      render(<Pagination totalItems={500} itemsPerPage={10} defaultPage={1} />);
+
+      // totalPages = 50, current = 1 → should see ellipsis before last page
+      const ellipses = screen.queryAllByText('…');
+      expect(ellipses.length).toBeGreaterThan(0);
+    });
+
+    it('shows first and last page when there are many pages', () => {
+      render(
+        <Pagination totalItems={500} itemsPerPage={10} defaultPage={25} />
+      );
+
+      // totalPages = 50, current = 25
+      expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
+      expect(screen.getByLabelText('Page 50')).toBeInTheDocument();
+    });
+
+    it('shows ellipsis on both sides when current page is in the middle', () => {
+      render(
+        <Pagination totalItems={500} itemsPerPage={10} defaultPage={25} />
+      );
+
+      // Should have two ellipsis elements (before first chunk, after last chunk)
+      const ellipses = screen.queryAllByText('…');
+      expect(ellipses.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('items-per-page change resets to page 1', () => {
+    it('resets to page 1 when items-per-page is changed', async () => {
+      const onPageChange = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Pagination
+          totalItems={200}
+          itemsPerPage={10}
+          defaultPage={5}
+          onPageChange={onPageChange}
+          showItemsPerPage={true}
+          itemsPerPageOptions={[10, 25, 50]}
+        />
+      );
+
+      // Start at page 5
+      expect(onPageChange).not.toHaveBeenCalled();
+
+      // Change items per page to 25
+      const select = screen.getByLabelText('Per page:');
+      await user.selectOptions(select, '25');
+
+      // Should call onPageChange with page 1
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('go-to-page input clamping', () => {
+    it('clamps input above totalPages to last page', () => {
+      const onPageChange = jest.fn();
+      render(
+        <Pagination
+          totalItems={100}
+          itemsPerPage={10}
+          defaultPage={1}
+          onPageChange={onPageChange}
+          showGoToPage={true}
+        />
+      );
+
+      // totalPages = 10
+      const goToInput = screen.getByLabelText(/Go to page/);
+      fireEvent.change(goToInput, { target: { value: '999' } });
+      fireEvent.blur(goToInput);
+
+      expect(onPageChange).toHaveBeenCalledWith(10);
+    });
+
+    it('clamps input below 1 to page 1', () => {
+      const onPageChange = jest.fn();
+      render(
+        <Pagination
+          totalItems={100}
+          itemsPerPage={10}
+          defaultPage={5}
+          onPageChange={onPageChange}
+          showGoToPage={true}
+        />
+      );
+
+      const goToInput = screen.getByLabelText(/Go to page/);
+      fireEvent.change(goToInput, { target: { value: '0' } });
+      fireEvent.blur(goToInput);
+
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+
+    it('navigates to valid page number on Enter', () => {
+      const onPageChange = jest.fn();
+      render(
+        <Pagination
+          totalItems={100}
+          itemsPerPage={10}
+          defaultPage={1}
+          onPageChange={onPageChange}
+          showGoToPage={true}
+        />
+      );
+
+      const goToInput = screen.getByLabelText(/Go to page/);
+      fireEvent.change(goToInput, { target: { value: '7' } });
+      fireEvent.keyDown(goToInput, { key: 'Enter' });
+
+      expect(onPageChange).toHaveBeenCalledWith(7);
+    });
+
+    it('does nothing on Enter when input is empty', () => {
+      const onPageChange = jest.fn();
+      render(
+        <Pagination
+          totalItems={100}
+          itemsPerPage={10}
+          defaultPage={1}
+          onPageChange={onPageChange}
+          showGoToPage={true}
+        />
+      );
+
+      const goToInput = screen.getByLabelText(/Go to page/);
+      fireEvent.keyDown(goToInput, { key: 'Enter' });
+
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+
+    it('clamps negative page to 1 on blur', () => {
+      const onPageChange = jest.fn();
+      render(
+        <Pagination
+          totalItems={100}
+          itemsPerPage={10}
+          defaultPage={3}
+          onPageChange={onPageChange}
+          showGoToPage={true}
+        />
+      );
+
+      const goToInput = screen.getByLabelText(/Go to page/);
+      fireEvent.change(goToInput, { target: { value: '-5' } });
+      fireEvent.blur(goToInput);
+
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('navigation buttons', () => {
+    it('disables previous and first buttons on page 1', () => {
+      render(<Pagination totalItems={100} itemsPerPage={10} defaultPage={1} />);
+
+      expect(screen.getByLabelText('First page')).toBeDisabled();
+      expect(screen.getByLabelText('Previous page')).toBeDisabled();
+      expect(screen.getByLabelText('Next page')).not.toBeDisabled();
+    });
+
+    it('disables next and last buttons on last page', () => {
+      render(
+        <Pagination totalItems={100} itemsPerPage={10} defaultPage={10} />
+      );
+
+      expect(screen.getByLabelText('Next page')).toBeDisabled();
+      expect(screen.getByLabelText('Last page')).toBeDisabled();
+      expect(screen.getByLabelText('Previous page')).not.toBeDisabled();
+    });
+
+    it('calls onPageChange when navigating to next page', async () => {
+      const onPageChange = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Pagination
+          totalItems={100}
+          itemsPerPage={10}
+          defaultPage={1}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByLabelText('Next page'));
+      expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it('calls onPageChange when navigating to previous page', async () => {
+      const onPageChange = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Pagination
+          totalItems={100}
+          itemsPerPage={10}
+          defaultPage={5}
+          onPageChange={onPageChange}
+        />
+      );
+
+      await user.click(screen.getByLabelText('Previous page'));
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null when totalItems is 0', () => {
+      const { container } = render(<Pagination totalItems={0} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('shows only one page when totalItems is less than itemsPerPage', () => {
+      render(<Pagination totalItems={5} itemsPerPage={10} />);
+
+      expect(screen.getByLabelText('Page 1')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Page 2')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('First page')).toBeDisabled();
+      expect(screen.getByLabelText('Last page')).toBeDisabled();
+    });
+
+    it('shows go-to-page input only when totalPages > 5', () => {
+      const { container } = render(
+        <Pagination totalItems={30} itemsPerPage={10} showGoToPage={true} />
+      );
+      // totalPages = 3, should not show go-to-page
+      expect(screen.queryByLabelText(/Go to page/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/nevo_frontend/__tests__/env.test.ts
+++ b/nevo_frontend/__tests__/env.test.ts
@@ -12,10 +12,39 @@ describe('public env configuration', () => {
     process.env = originalEnv;
   });
 
-  it('falls back to default values when public env vars are missing', async () => {
-    const { env } = await import('../lib/env');
+  describe('env object', () => {
+    it('falls back to default values when public env vars are missing', async () => {
+      const { env } = await import('../lib/env');
 
-    expect(env.NEXT_PUBLIC_API_BASE_URL).toBe('http://localhost:3000');
-    expect(env.NEXT_PUBLIC_STELLAR_NETWORK).toBe('testnet');
+      expect(env.NEXT_PUBLIC_API_BASE_URL).toBe('http://localhost:3000');
+      expect(env.NEXT_PUBLIC_STELLAR_NETWORK).toBe('testnet');
+    });
+
+    it('uses process.env values when they are set', async () => {
+      process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.example.com';
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'public';
+
+      const { env } = await import('../lib/env');
+
+      expect(env.NEXT_PUBLIC_API_BASE_URL).toBe('https://api.example.com');
+      expect(env.NEXT_PUBLIC_STELLAR_NETWORK).toBe('public');
+    });
+  });
+
+  describe('validatePublicEnv', () => {
+    it('completes without throwing when all required vars are present', async () => {
+      process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.example.com';
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'public';
+
+      const { validatePublicEnv } = await import('../lib/env');
+
+      expect(() => validatePublicEnv()).not.toThrow();
+    });
+
+    it('completes without throwing when vars are missing (falls back to defaults)', async () => {
+      const { validatePublicEnv } = await import('../lib/env');
+
+      expect(() => validatePublicEnv()).not.toThrow();
+    });
   });
 });

--- a/nevo_frontend/__tests__/validation.test.ts
+++ b/nevo_frontend/__tests__/validation.test.ts
@@ -1,0 +1,325 @@
+import {
+  isEmail,
+  isPhone,
+  isUrl,
+  isCurrencyAmount,
+  minLength,
+  maxLength,
+  runValidation,
+  isRequired,
+} from '../lib/validation';
+
+describe('isRequired', () => {
+  it('rejects null', async () => {
+    const rule = isRequired();
+    expect(await rule.validate(null)).toBe(false);
+  });
+
+  it('rejects undefined', async () => {
+    const rule = isRequired();
+    expect(await rule.validate(undefined)).toBe(false);
+  });
+
+  it('rejects empty string', async () => {
+    const rule = isRequired();
+    expect(await rule.validate('')).toBe(false);
+  });
+
+  it('rejects whitespace-only string', async () => {
+    const rule = isRequired();
+    expect(await rule.validate('   ')).toBe(false);
+  });
+
+  it('rejects empty array', async () => {
+    const rule = isRequired();
+    expect(await rule.validate([])).toBe(false);
+  });
+
+  it('accepts non-empty string', async () => {
+    const rule = isRequired();
+    expect(await rule.validate('hello')).toBe(true);
+  });
+
+  it('accepts non-empty array', async () => {
+    const rule = isRequired();
+    expect(await rule.validate([1, 2])).toBe(true);
+  });
+
+  it('accepts number zero', async () => {
+    const rule = isRequired();
+    expect(await rule.validate(0)).toBe(true);
+  });
+
+  it('accepts boolean false', async () => {
+    const rule = isRequired();
+    expect(await rule.validate(false)).toBe(true);
+  });
+
+  it('uses custom message', () => {
+    const rule = isRequired('Custom required message');
+    expect(rule.message).toBe('Custom required message');
+  });
+});
+
+describe('isEmail', () => {
+  const rule = isEmail();
+
+  it('returns true for empty value (delegates to required)', async () => {
+    expect(await rule.validate('')).toBe(true);
+  });
+
+  it('returns true for valid email', async () => {
+    expect(await rule.validate('user@example.com')).toBe(true);
+  });
+
+  it('returns true for email with plus sign', async () => {
+    expect(await rule.validate('user+tag@example.com')).toBe(true);
+  });
+
+  it('returns true for email with subdomain', async () => {
+    expect(await rule.validate('user@mail.example.co.uk')).toBe(true);
+  });
+
+  it('returns false for missing @', async () => {
+    expect(await rule.validate('userexample.com')).toBe(false);
+  });
+
+  it('returns false for missing domain', async () => {
+    expect(await rule.validate('user@')).toBe(false);
+  });
+
+  it('returns false for missing TLD', async () => {
+    expect(await rule.validate('user@example')).toBe(false);
+  });
+
+  it('returns false for spaces', async () => {
+    expect(await rule.validate('user @example.com')).toBe(false);
+  });
+
+  it('uses custom message', () => {
+    const customRule = isEmail('Bad email');
+    expect(customRule.message).toBe('Bad email');
+  });
+});
+
+describe('isPhone', () => {
+  const rule = isPhone();
+
+  it('returns true for empty value', async () => {
+    expect(await rule.validate('')).toBe(true);
+  });
+
+  it('returns true for 10-digit number', async () => {
+    expect(await rule.validate('1234567890')).toBe(true);
+  });
+
+  it('returns true for number with dashes', async () => {
+    expect(await rule.validate('123-456-7890')).toBe(true);
+  });
+
+  it('returns true for number with spaces', async () => {
+    expect(await rule.validate('123 456 7890')).toBe(true);
+  });
+
+  it('returns true for number with country code', async () => {
+    expect(await rule.validate('+11234567890')).toBe(true);
+  });
+
+  it('returns false for too short', async () => {
+    expect(await rule.validate('12345')).toBe(false);
+  });
+
+  it('returns false for letters', async () => {
+    expect(await rule.validate('abcdefghij')).toBe(false);
+  });
+
+  it('returns false for exactly 9 digits', async () => {
+    expect(await rule.validate('123456789')).toBe(false);
+  });
+});
+
+describe('isUrl', () => {
+  const rule = isUrl();
+
+  it('returns true for empty value', async () => {
+    expect(await rule.validate('')).toBe(true);
+  });
+
+  it('returns true for https URL', async () => {
+    expect(await rule.validate('https://example.com')).toBe(true);
+  });
+
+  it('returns true for http URL', async () => {
+    expect(await rule.validate('http://example.com')).toBe(true);
+  });
+
+  it('returns true for URL with path', async () => {
+    expect(await rule.validate('https://example.com/path/to/page')).toBe(true);
+  });
+
+  it('returns true for URL with query params', async () => {
+    expect(await rule.validate('https://example.com?foo=bar')).toBe(true);
+  });
+
+  it('returns false for invalid URL', async () => {
+    expect(await rule.validate('not-a-url')).toBe(false);
+  });
+
+  it('returns false for missing protocol', async () => {
+    expect(await rule.validate('example.com')).toBe(false);
+  });
+});
+
+describe('isCurrencyAmount', () => {
+  const rule = isCurrencyAmount();
+
+  it('returns true for empty value', async () => {
+    expect(await rule.validate('')).toBe(true);
+  });
+
+  it('returns true for null', async () => {
+    expect(await rule.validate(null)).toBe(true);
+  });
+
+  it('returns true for undefined', async () => {
+    expect(await rule.validate(undefined)).toBe(true);
+  });
+
+  it('returns true for whole number', async () => {
+    expect(await rule.validate('100')).toBe(true);
+  });
+
+  it('returns true for zero', async () => {
+    expect(await rule.validate('0')).toBe(true);
+  });
+
+  it('returns true for number with two decimal places', async () => {
+    expect(await rule.validate('100.50')).toBe(true);
+  });
+
+  it('returns true for number with one decimal place', async () => {
+    expect(await rule.validate('100.5')).toBe(true);
+  });
+
+  it('returns false for three decimal places', async () => {
+    expect(await rule.validate('100.555')).toBe(false);
+  });
+
+  it('returns false for letters', async () => {
+    expect(await rule.validate('abc')).toBe(false);
+  });
+
+  it('returns false for negative number', async () => {
+    expect(await rule.validate('-100')).toBe(false);
+  });
+
+  it('accepts numeric input', async () => {
+    expect(await rule.validate(42)).toBe(true);
+  });
+
+  it('accepts numeric float', async () => {
+    expect(await rule.validate(42.99)).toBe(true);
+  });
+});
+
+describe('minLength', () => {
+  it('returns true for empty value', async () => {
+    const rule = minLength(5);
+    expect(await rule.validate('')).toBe(true);
+  });
+
+  it('returns true when length equals min', async () => {
+    const rule = minLength(5);
+    expect(await rule.validate('hello')).toBe(true);
+  });
+
+  it('returns true when length exceeds min', async () => {
+    const rule = minLength(5);
+    expect(await rule.validate('hello world')).toBe(true);
+  });
+
+  it('returns false when length is below min', async () => {
+    const rule = minLength(5);
+    expect(await rule.validate('hi')).toBe(false);
+  });
+
+  it('uses default message', () => {
+    const rule = minLength(3);
+    expect(rule.message).toBe('Minimum length is 3 characters');
+  });
+
+  it('uses custom message', () => {
+    const rule = minLength(3, 'Too short!');
+    expect(rule.message).toBe('Too short!');
+  });
+});
+
+describe('maxLength', () => {
+  it('returns true for empty value', async () => {
+    const rule = maxLength(5);
+    expect(await rule.validate('')).toBe(true);
+  });
+
+  it('returns true when length equals max', async () => {
+    const rule = maxLength(5);
+    expect(await rule.validate('hello')).toBe(true);
+  });
+
+  it('returns true when length is below max', async () => {
+    const rule = maxLength(10);
+    expect(await rule.validate('hi')).toBe(true);
+  });
+
+  it('returns false when length exceeds max', async () => {
+    const rule = maxLength(5);
+    expect(await rule.validate('hello world')).toBe(false);
+  });
+
+  it('uses default message', () => {
+    const rule = maxLength(10);
+    expect(rule.message).toBe('Maximum length is 10 characters');
+  });
+
+  it('uses custom message', () => {
+    const rule = maxLength(10, 'Too long!');
+    expect(rule.message).toBe('Too long!');
+  });
+});
+
+describe('runValidation', () => {
+  it('returns null when all rules pass', async () => {
+    const result = await runValidation('test@example.com', [
+      isRequired(),
+      isEmail(),
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns first failing rule message', async () => {
+    const result = await runValidation('', [
+      isRequired('Field is required'),
+      isEmail(),
+    ]);
+    expect(result).toBe('Field is required');
+  });
+
+  it('returns second rule message when first passes', async () => {
+    const result = await runValidation('not-an-email', [
+      isRequired(),
+      isEmail('Invalid email'),
+    ]);
+    expect(result).toBe('Invalid email');
+  });
+
+  it('returns null for empty rules array', async () => {
+    const result = await runValidation('anything', []);
+    expect(result).toBeNull();
+  });
+
+  it('works with multiple rules and returns first failure', async () => {
+    const rules = [minLength(5, 'Too short'), isEmail('Invalid email')];
+    const result = await runValidation('x@y', rules);
+    // minLength(5) — 'x@y' has length 3, so should fail
+    expect(result).toBe('Too short');
+  });
+});

--- a/nevo_frontend/hooks/useXdrTransaction.test.ts
+++ b/nevo_frontend/hooks/useXdrTransaction.test.ts
@@ -1,0 +1,242 @@
+import { renderHook, act } from '@testing-library/react';
+import { useXdrTransaction } from './useXdrTransaction';
+
+jest.mock('@/lib/stellar', () => ({
+  signTransaction: jest.fn(),
+}));
+
+import { signTransaction } from '@/lib/stellar';
+
+const mockSignTransaction = signTransaction as jest.Mock;
+
+describe('useXdrTransaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('starts with idle status and null txHash/error', () => {
+      const { result } = renderHook(() => useXdrTransaction());
+
+      expect(result.current.status).toBe('idle');
+      expect(result.current.txHash).toBeNull();
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('success flow', () => {
+    it('transitions idle → signing → submitting → success with a string XDR payload', async () => {
+      mockSignTransaction.mockResolvedValue('signed-xdr-string');
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr-string');
+      const submitXdr = jest.fn().mockResolvedValue('tx-hash-abc123');
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      expect(result.current.status).toBe('idle');
+
+      let hash: unknown;
+      await act(async () => {
+        hash = await result.current.submit(getXdr, submitXdr);
+      });
+
+      // State transitions
+      expect(getXdr).toHaveBeenCalledTimes(1);
+      expect(mockSignTransaction).toHaveBeenCalledWith('unsigned-xdr-string');
+      expect(submitXdr).toHaveBeenCalledWith('signed-xdr-string');
+
+      expect(result.current.status).toBe('success');
+      expect(result.current.txHash).toBe('tx-hash-abc123');
+      expect(result.current.error).toBeNull();
+      expect(hash).toBe('tx-hash-abc123');
+    });
+
+    it('handles object XDR payload with unsignedXdr property', async () => {
+      mockSignTransaction.mockResolvedValue('signed-xdr-obj');
+      const getXdr = jest
+        .fn()
+        .mockResolvedValue({ unsignedXdr: 'unsigned-xdr-from-object' });
+      const submitXdr = jest.fn().mockResolvedValue('tx-hash-def456');
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        await result.current.submit(getXdr, submitXdr);
+      });
+
+      expect(mockSignTransaction).toHaveBeenCalledWith(
+        'unsigned-xdr-from-object'
+      );
+      expect(submitXdr).toHaveBeenCalledWith('signed-xdr-obj');
+      expect(result.current.status).toBe('success');
+      expect(result.current.txHash).toBe('tx-hash-def456');
+    });
+
+    it('extracts txHash from object result with hash property', async () => {
+      mockSignTransaction.mockResolvedValue('signed-xdr');
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr');
+      const submitXdr = jest.fn().mockResolvedValue({ hash: 'hash-from-obj' });
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        await result.current.submit(getXdr, submitXdr);
+      });
+
+      expect(result.current.status).toBe('success');
+      expect(result.current.txHash).toBe('hash-from-obj');
+    });
+
+    it('extracts txHash from object result with txHash property', async () => {
+      mockSignTransaction.mockResolvedValue('signed-xdr');
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr');
+      const submitXdr = jest
+        .fn()
+        .mockResolvedValue({ txHash: 'txhash-from-obj' });
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        await result.current.submit(getXdr, submitXdr);
+      });
+
+      expect(result.current.status).toBe('success');
+      expect(result.current.txHash).toBe('txhash-from-obj');
+    });
+  });
+
+  describe('error flow', () => {
+    it('transitions idle → signing → error when getXdr throws', async () => {
+      const getXdr = jest
+        .fn()
+        .mockRejectedValue(new Error('Failed to get XDR'));
+      const submitXdr = jest.fn();
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        try {
+          await result.current.submit(getXdr, submitXdr);
+        } catch (_) {
+          // expected
+        }
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toBe('Failed to get XDR');
+      expect(result.current.txHash).toBeNull();
+      expect(submitXdr).not.toHaveBeenCalled();
+    });
+
+    it('transitions idle → signing → error when signTransaction throws', async () => {
+      mockSignTransaction.mockRejectedValue(new Error('User rejected'));
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr');
+      const submitXdr = jest.fn();
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        try {
+          await result.current.submit(getXdr, submitXdr);
+        } catch (_) {
+          // expected
+        }
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toBe('User rejected');
+      expect(result.current.txHash).toBeNull();
+      expect(submitXdr).not.toHaveBeenCalled();
+    });
+
+    it('transitions idle → signing → submitting → error when submitXdr throws', async () => {
+      mockSignTransaction.mockResolvedValue('signed-xdr');
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr');
+      const submitXdr = jest.fn().mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        try {
+          await result.current.submit(getXdr, submitXdr);
+        } catch (_) {
+          // expected
+        }
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toBe('Network error');
+      expect(result.current.txHash).toBeNull();
+    });
+
+    it('uses fallback message for non-Error throws', async () => {
+      mockSignTransaction.mockRejectedValue('plain string error');
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr');
+      const submitXdr = jest.fn();
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        try {
+          await result.current.submit(getXdr, submitXdr);
+        } catch (_) {
+          // expected
+        }
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toBe('Failed to submit transaction');
+    });
+
+    it('re-throws the error after setting error state', async () => {
+      const error = new Error('Test error');
+      mockSignTransaction.mockRejectedValue(error);
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr');
+      const submitXdr = jest.fn();
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      let caught: unknown;
+      await act(async () => {
+        try {
+          await result.current.submit(getXdr, submitXdr);
+        } catch (e) {
+          caught = e;
+        }
+      });
+
+      expect(caught).toBe(error);
+      expect(result.current.status).toBe('error');
+    });
+  });
+
+  describe('state reset', () => {
+    it('clears previous error and txHash on a new submit call', async () => {
+      // First call: error
+      mockSignTransaction.mockRejectedValueOnce(new Error('First error'));
+      const getXdr = jest.fn().mockResolvedValue('unsigned-xdr');
+      const submitXdr = jest.fn();
+
+      const { result } = renderHook(() => useXdrTransaction());
+
+      await act(async () => {
+        try {
+          await result.current.submit(getXdr, submitXdr);
+        } catch (_) {}
+      });
+
+      expect(result.current.error).toBe('First error');
+
+      // Second call: success
+      mockSignTransaction.mockResolvedValue('signed-xdr');
+      submitXdr.mockResolvedValue('new-tx-hash');
+
+      await act(async () => {
+        await result.current.submit(getXdr, submitXdr);
+      });
+
+      expect(result.current.status).toBe('success');
+      expect(result.current.error).toBeNull();
+      expect(result.current.txHash).toBe('new-tx-hash');
+    });
+  });
+});


### PR DESCRIPTION
Closes #833
Closes #836
Closes #837
Closes #839


Deliverables 
 Create components/Pagination.test.tsx
 Cover: page-range rendering with ellipses for large page counts, items-per-page change resetting to page 1, and "go to page" input clamping to valid page numbers
 npm test passes
 npm run build passes
 
 Create lib/env.test.ts
 Cover: getRequiredPublicEnvVar returning a value when set, throwing when unset; validatePublicEnv passing when all required vars are present and failing with a clear message when one is missing
 npm test passes
 npm run build passes
 
  Create lib/validation.test.ts
 Cover valid and invalid inputs for each exported validator, plus runValidation's aggregation of multiple rules
 npm test passes
 npm run build passes
 
 Create hooks/useXdrTransaction.test.ts
 Cover: idle → pending → success transition, idle → pending → error transition, and both accepted XDR payload shapes
 npm test passes
 npm run build passes