### PR TITLE
feat(contract): introduce ContractError enum (#955) and standardize e…

### DIFF
--- a/nevo_contract/contracts/hello-world/src/lib.rs
+++ b/nevo_contract/contracts/hello-world/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(test), no_std)]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, String,
+    Symbol, Vec,
 };
 
 // Storage key constants
@@ -54,6 +55,59 @@ const DONATION_MADE: Symbol = symbol_short!("donation");
 const CONTRIBUTION: Symbol = symbol_short!("contrib");
 const POOL_CLOSED: Symbol = symbol_short!("pool_cls");
 const APPLICATION_SUBMITTED: Symbol = symbol_short!("app_sub");
+
+// Issue #954: named constants for previously-uneventful state-changing functions
+const APP_APPROVED: Symbol = symbol_short!("app_aprvd");
+const MILESTONES_SET: Symbol = symbol_short!("mile_set");
+const FUNDS_CLAIMED: Symbol = symbol_short!("fund_clmd");
+const FEES_CLAIMED: Symbol = symbol_short!("fees_clmd");
+const DONATION_REFUND: Symbol = symbol_short!("don_refnd");
+const DEADLINE_SET: Symbol = symbol_short!("ddln_set");
+const POOL_STATE_SET: Symbol = symbol_short!("pool_stat");
+const SCHOOL_REG: Symbol = symbol_short!("schl_reg");
+const ADMIN_SET: Symbol = symbol_short!("admin_set");
+// Issue #954: shared constant replacing inline Symbol::new(&env, "creation_fee_updated")
+const FEE_UPDATED: Symbol = symbol_short!("fee_upd");
+
+// ─── Typed Error Enum (Issue #955) ───────────────────────────────────────
+
+/// All contract-level error conditions, encoded as XDR for off-chain callers.
+///
+/// Use `env.panic_with_error(ContractError::Variant)` instead of
+/// `panic!("string literal")` for these conditions so that the error is
+/// stable across contract versions and machine-readable.
+#[contracterror]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    /// Pool with the given ID does not exist in storage.
+    PoolNotFound = 1,
+    /// Pool is not in the state required for this operation.
+    InvalidPoolState = 2,
+    /// Caller is not the stored platform admin.
+    UnauthorizedAdmin = 3,
+    /// Operation rejected because the pool is already closed.
+    PoolIsClosed = 4,
+    /// Student has already submitted an application for this pool.
+    DuplicateApplication = 5,
+    /// Student has not applied to this pool.
+    StudentHasNotApplied = 6,
+    /// Only the school linked to the pool may approve applications.
+    OnlyLinkedSchoolCanApprove = 7,
+    /// Pool must be in Disbursed or Cancelled state before it can be closed.
+    PoolNotDisbursedOrRefunded = 8,
+    /// No admin address has been configured in storage.
+    AdminNotSet = 9,
+    /// There are no accumulated protocol fees to claim.
+    NoUnclaimedFees = 10,
+    /// Fee value is invalid (e.g. negative).
+    InvalidFee = 11,
+    /// Pool deadline has not yet passed (or grace period not elapsed).
+    PoolNotExpired = 12,
+    /// Donor has no recorded contribution in this pool to refund.
+    NoContributionToRefund = 13,
+    /// School address has not been registered by an admin.
+    SchoolNotRegistered = 14,
+}
 
 // Helper functions for timestamp/deadline edge-case tests
 // These are deterministic, test-oriented helpers used by unit tests
@@ -167,6 +221,9 @@ impl Contract {
         admin.require_auth();
         let admin_key = Symbol::new(&env, ADMIN_KEY);
         env.storage().persistent().set(&admin_key, &admin);
+
+        // Issue #954: emit admin-set event
+        env.events().publish((ADMIN_SET,), admin.clone());
     }
 
     /// Register a school by admin authorization.
@@ -178,13 +235,17 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Address>(&admin_key)
-            .expect("Admin not set");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::AdminNotSet));
         if stored_admin != admin {
-            panic!("Unauthorized admin");
+            env.panic_with_error(ContractError::UnauthorizedAdmin);
         }
 
-        let school_key = (Symbol::new(&env, SCHOOL_REG_PREFIX), school);
+        let school_key = (Symbol::new(&env, SCHOOL_REG_PREFIX), school.clone());
         env.storage().persistent().set(&school_key, &true);
+
+        // Issue #954: emit school-registered event
+        env.events()
+            .publish((SCHOOL_REG, admin.clone()), school.clone());
     }
 
     /// Check if a school has been registered.
@@ -275,7 +336,7 @@ impl Contract {
         creator.require_auth();
 
         if !Self::is_school_registered(env.clone(), school.clone()) {
-            panic!("School is not registered");
+            env.panic_with_error(ContractError::SchoolNotRegistered);
         }
 
         let pool_id = Self::create_pool(
@@ -306,16 +367,16 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         if pool.is_closed {
-            panic!("Pool is closed");
+            env.panic_with_error(ContractError::PoolIsClosed);
         }
 
         // TODO: Replace with real implementation from issue #XYZ
         // Pool state validation
         if pool.state != PoolState::Active {
-            panic!("InvalidPoolState");
+            env.panic_with_error(ContractError::InvalidPoolState);
         }
 
         let new_collected = pool.collected + amount;
@@ -372,7 +433,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         (
             pool_id,
@@ -418,7 +479,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         pool.collected
     }
@@ -429,12 +490,12 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         pool.sponsor.require_auth();
 
         if pool.state != PoolState::Disbursed && pool.state != PoolState::Cancelled {
-            panic!("PoolNotDisbursedOrRefunded");
+            env.panic_with_error(ContractError::PoolNotDisbursedOrRefunded);
         }
 
         let updated_pool = Pool {
@@ -471,7 +532,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         env.storage()
             .persistent()
@@ -486,7 +547,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         env.storage()
             .persistent()
@@ -502,7 +563,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         let applicant_key = (
             Symbol::new(&env, APPLICANT_PREFIX),
@@ -510,7 +571,7 @@ impl Contract {
             student.clone(),
         );
         if env.storage().persistent().has(&applicant_key) {
-            panic!("Duplicate application");
+            env.panic_with_error(ContractError::DuplicateApplication);
         }
 
         let count_key = (Symbol::new(&env, APPLICATION_COUNT_PREFIX), pool_id);
@@ -551,7 +612,7 @@ impl Contract {
 
         let linked_school = Self::get_pool_school(env.clone(), pool_id);
         if linked_school != school {
-            panic!("Only linked school can approve");
+            env.panic_with_error(ContractError::OnlyLinkedSchoolCanApprove);
         }
 
         let applicant_key = (
@@ -560,7 +621,7 @@ impl Contract {
             student.clone(),
         );
         if !env.storage().persistent().has(&applicant_key) {
-            panic!("Student has not applied");
+            env.panic_with_error(ContractError::StudentHasNotApplied);
         }
 
         let status = if approved {
@@ -568,7 +629,11 @@ impl Contract {
         } else {
             String::from_str(&env, APPLICATION_STATUS_REJECTED)
         };
-        Self::set_application_status(env, pool_id, student, status);
+        Self::set_application_status(env.clone(), pool_id, student.clone(), status);
+
+        // Issue #954: emit application-approved event
+        env.events()
+            .publish((APP_APPROVED, pool_id), (student.clone(), approved));
     }
 
     /// Set application milestones and enforce sum(amounts) == pool goal.
@@ -584,7 +649,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         if milestones.is_empty() {
             panic!("Milestones required");
@@ -601,8 +666,12 @@ impl Contract {
             panic!("Milestone total must equal pool goal");
         }
 
-        let milestones_key = (Symbol::new(&env, MILESTONES_PREFIX), pool_id, student);
+        let milestones_key = (Symbol::new(&env, MILESTONES_PREFIX), pool_id, student.clone());
         env.storage().persistent().set(&milestones_key, &milestones);
+
+        // Issue #954: emit milestones-set event
+        env.events()
+            .publish((MILESTONES_SET, pool_id), (student.clone(), milestones.len()));
     }
 
     /// Get student milestones for a pool.
@@ -670,7 +739,7 @@ impl Contract {
     /// Surplus = pool.collected - locked_funds.
     ///
     /// # Panics
-    /// - `"Pool not found"` if pool_id is invalid
+    /// - `ContractError::PoolNotFound` if pool_id is invalid
     /// - `"Insolvency: locked funds exceed collected"` if locked > collected
     /// - `"No surplus to withdraw"` if surplus == 0
     pub fn withdraw_unallocated_funds(env: Env, pool_id: u32, token_address: Address) {
@@ -678,7 +747,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         pool.sponsor.require_auth();
 
@@ -801,7 +870,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         let collected = pool.collected as i128;
 
@@ -847,6 +916,12 @@ impl Contract {
         // Persist the updated running total
         application.amount_claimed += claim_amount;
         env.storage().persistent().set(&app_key, &application);
+
+        // Issue #954: emit funds-claimed event
+        env.events().publish(
+            (FUNDS_CLAIMED, pool_id),
+            (student.clone(), claim_amount, application.amount_claimed),
+        );
     }
 
     /// Claim accumulated protocol fees on behalf of the protocol/treasury.
@@ -860,8 +935,8 @@ impl Contract {
     /// * `token_address` - The token to transfer fees as
     ///
     /// # Panics
-    /// - `"Unauthorized admin"` if the caller is not the stored admin address
-    /// - `"No unclaimed fees"` if there are no accumulated fees to claim
+    /// - `ContractError::UnauthorizedAdmin` if the caller is not the stored admin address
+    /// - `ContractError::NoUnclaimedFees` if there are no accumulated fees to claim
     pub fn claim_protocol_fees(env: Env, admin: Address, token_address: Address) -> i128 {
         admin.require_auth();
 
@@ -871,9 +946,9 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Address>(&admin_key)
-            .expect("Admin not set");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::AdminNotSet));
         if stored_admin != admin {
-            panic!("Unauthorized admin");
+            env.panic_with_error(ContractError::UnauthorizedAdmin);
         }
 
         // Get accumulated unclaimed fees
@@ -885,7 +960,7 @@ impl Contract {
             .unwrap_or(0);
 
         if fees == 0 {
-            panic!("No unclaimed fees");
+            env.panic_with_error(ContractError::NoUnclaimedFees);
         }
 
         // Transfer accumulated fees to admin
@@ -894,6 +969,10 @@ impl Contract {
 
         // Reset unclaimed fees to 0
         env.storage().persistent().set(&unclaimed_fees_key, &0i128);
+
+        // Issue #954: emit fees-claimed event
+        env.events()
+            .publish((FEES_CLAIMED, admin.clone()), (fees,));
 
         fees
     }
@@ -904,14 +983,14 @@ impl Contract {
     ///
     /// Only the stored admin may call this function.
     /// A fee of zero is valid (disables the creation fee).
-    /// A negative fee panics with `"InvalidFee"`.
+    /// A negative fee panics with `ContractError::InvalidFee`.
     ///
-    /// Emits a `creation_fee_updated` event on success.
+    /// Emits a `FEE_UPDATED` event on success.
     ///
     /// # Panics
-    /// - `"Admin not set"` if no admin has been configured
-    /// - `"Unauthorized admin"` if `admin` does not match the stored admin
-    /// - `"InvalidFee"` if `fee` is negative
+    /// - `ContractError::AdminNotSet` if no admin has been configured
+    /// - `ContractError::UnauthorizedAdmin` if `admin` does not match the stored admin
+    /// - `ContractError::InvalidFee` if `fee` is negative
     pub fn set_creation_fee(env: Env, admin: Address, fee: i128) {
         admin.require_auth();
 
@@ -920,21 +999,20 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Address>(&admin_key)
-            .expect("Admin not set");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::AdminNotSet));
         if stored_admin != admin {
-            panic!("Unauthorized admin");
+            env.panic_with_error(ContractError::UnauthorizedAdmin);
         }
 
         if fee < 0 {
-            panic!("InvalidFee");
+            env.panic_with_error(ContractError::InvalidFee);
         }
 
         let fee_key = Symbol::new(&env, CREATION_FEE_KEY);
         env.storage().persistent().set(&fee_key, &fee);
 
-        // Emit event: topics = ["creation_fee_updated"], data = new fee value
-        env.events()
-            .publish((Symbol::new(&env, "creation_fee_updated"),), fee);
+        // Issue #954: use shared FEE_UPDATED constant instead of inline Symbol::new
+        env.events().publish((FEE_UPDATED,), fee);
     }
 
     /// Get the current pool creation fee.
@@ -955,7 +1033,7 @@ impl Contract {
     /// The deadline must be in the future (greater than the current ledger).
     ///
     /// # Panics
-    /// - `"Pool not found"` if pool_id is invalid
+    /// - `ContractError::PoolNotFound` if pool_id is invalid
     /// - `"Error(Auth, InvalidAction)"` if caller is not the pool sponsor
     /// - `"Deadline must be in the future"` if deadline <= current ledger
     pub fn set_pool_deadline(env: Env, pool_id: u32, deadline: u32) {
@@ -963,7 +1041,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         pool.sponsor.require_auth();
 
@@ -973,6 +1051,10 @@ impl Contract {
 
         let deadline_key = (Symbol::new(&env, POOL_DEADLINE_PREFIX), pool_id);
         env.storage().persistent().set(&deadline_key, &deadline);
+
+        // Issue #954: emit deadline-set event
+        env.events()
+            .publish((DEADLINE_SET, pool_id), (pool.sponsor.clone(), deadline));
     }
 
     /// Get the refund deadline ledger for a pool.
@@ -995,11 +1077,9 @@ impl Contract {
     ///      (`current_ledger >= deadline + REFUND_GRACE_PERIOD_LEDGERS`).
     ///
     /// # Panics
-    /// - `"Pool not found"` if pool_id is invalid
-    /// - `"PoolNotExpired"` if the deadline has not passed yet
-    /// - `"PoolNotExpired"` if the pool is exactly at the deadline (no grace)
-    /// - `"PoolNotExpired"` if inside the grace period
-    /// - `"No contribution to refund"` if the donor has no recorded contribution
+    /// - `ContractError::PoolNotFound` if pool_id is invalid
+    /// - `ContractError::PoolNotExpired` if the deadline has not passed (or grace not elapsed)
+    /// - `ContractError::NoContributionToRefund` if the donor has no recorded contribution
     pub fn refund_donation(env: Env, pool_id: u32, donor: Address, token_address: Address) {
         donor.require_auth();
 
@@ -1007,7 +1087,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         let deadline_key = (Symbol::new(&env, POOL_DEADLINE_PREFIX), pool_id);
         let deadline: u32 = env
@@ -1023,7 +1103,7 @@ impl Contract {
             || current_ledger <= deadline
             || current_ledger < deadline + REFUND_GRACE_PERIOD_LEDGERS
         {
-            panic!("PoolNotExpired");
+            env.panic_with_error(ContractError::PoolNotExpired);
         }
 
         let contrib_key = (pool_id, "contribution", &donor);
@@ -1034,7 +1114,7 @@ impl Contract {
             .unwrap_or(0);
 
         if contribution == 0 {
-            panic!("No contribution to refund");
+            env.panic_with_error(ContractError::NoContributionToRefund);
         }
 
         // Clear the contribution record before transferring (re-entrancy guard)
@@ -1050,6 +1130,10 @@ impl Contract {
             &donor,
             &(contribution as i128),
         );
+
+        // Issue #954: emit donation-refund event
+        env.events()
+            .publish((DONATION_REFUND, pool_id), (donor.clone(), contribution));
     }
 
     /// Donate to a pool using a specific token.
@@ -1066,16 +1150,16 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
         if pool.is_closed {
-            panic!("Pool is closed");
+            env.panic_with_error(ContractError::PoolIsClosed);
         }
 
         // TODO: Replace with real implementation from issue #XYZ
         // Pool state validation
         if pool.state != PoolState::Active {
-            panic!("InvalidPoolState");
+            env.panic_with_error(ContractError::InvalidPoolState);
         }
 
         if amount <= 0 {
@@ -1152,7 +1236,7 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Address>(&admin_key)
-            .expect("Admin not set");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::AdminNotSet));
         if stored_admin != admin {
             panic!("Error(Auth, InvalidAction)");
         }
@@ -1206,10 +1290,15 @@ impl Contract {
             .storage()
             .persistent()
             .get::<_, Pool>(&pool_id)
-            .expect("Pool not found");
+            .unwrap_or_else(|| env.panic_with_error(ContractError::PoolNotFound));
 
-        pool.state = state;
+        let old_state = pool.state.clone();
+        pool.state = state.clone();
         env.storage().persistent().set(&pool_id, &pool);
+
+        // Issue #954: emit pool-state-set event
+        env.events()
+            .publish((POOL_STATE_SET, pool_id), (old_state, state));
     }
 }
 

--- a/nevo_contract/contracts/hello-world/src/test.rs
+++ b/nevo_contract/contracts/hello-world/src/test.rs
@@ -4,7 +4,7 @@ use super::*;
 use soroban_sdk::{
     testutils::{Address as _, MockAuth, MockAuthInvoke},
     token::StellarAssetClient,
-    Address, Env, IntoVal, String, Vec,
+    Address, Env, IntoVal, String,
 };
 
 fn create_token(env: &Env, amount: i128, recipient: &Address) -> Address {
@@ -105,7 +105,7 @@ fn test_close_pool() {
 }
 
 #[test]
-#[should_panic(expected = "Pool is closed")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_donate_to_closed_pool() {
     let env = Env::default();
     env.mock_all_auths();
@@ -181,7 +181,7 @@ fn test_multiple_pools() {
 }
 
 #[test]
-#[should_panic(expected = "InvalidAction")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_try_get_pool_returns_none_for_missing_pool() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
@@ -207,7 +207,7 @@ fn test_get_total_raised_starts_at_zero() {
 }
 
 #[test]
-#[should_panic(expected = "Pool not found")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_get_total_raised_rejects_missing_pool() {
     let env = Env::default();
     let contract_id = env.register(Contract, ());
@@ -401,7 +401,7 @@ fn test_protocol_fees_accumulation_on_claim() {
 }
 
 #[test]
-#[should_panic(expected = "Unauthorized admin")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_claim_protocol_fees_requires_admin_authorization() {
     let env = Env::default();
     env.mock_all_auths();
@@ -416,7 +416,7 @@ fn test_claim_protocol_fees_requires_admin_authorization() {
 }
 
 #[test]
-#[should_panic(expected = "No unclaimed fees")]
+#[should_panic(expected = "Error(Contract, #10)")]
 fn test_claim_protocol_fees_no_fees() {
     let env = Env::default();
     env.mock_all_auths();
@@ -463,7 +463,7 @@ fn test_claim_protocol_fees_multiple_claims_accumulate() {
 }
 
 #[test]
-#[should_panic(expected = "No unclaimed fees")]
+#[should_panic(expected = "Error(Contract, #10)")]
 fn test_protocol_fees_reset_after_claim() {
     let env = Env::default();
     env.mock_all_auths();

--- a/nevo_contract/contracts/hello-world/src/test_issues.rs
+++ b/nevo_contract/contracts/hello-world/src/test_issues.rs
@@ -2,9 +2,9 @@
 
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, Ledger},
     token::StellarAssetClient,
-    Address, Env, IntoVal, String, Symbol, Vec,
+    Address, Env, String, Symbol,
 };
 
 fn create_token(env: &Env, amount: i128, recipient: &Address) -> Address {
@@ -182,7 +182,7 @@ fn test_contribute_to_active_pool_succeeds() {
 
 /// Test 2: Contribute to Closed pool fails
 #[test]
-#[should_panic(expected = "Pool is closed")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_contribute_to_closed_pool_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -498,7 +498,7 @@ fn test_close_cancelled_pool_succeeds() {
 
 /// Test 3: Close pool in Active state fails with PoolNotDisbursedOrRefunded error
 #[test]
-#[should_panic(expected = "PoolNotDisbursedOrRefunded")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_close_active_pool_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -521,7 +521,7 @@ fn test_close_active_pool_fails() {
 
 /// Test 4: Close pool in Paused state fails with PoolNotDisbursedOrRefunded error
 #[test]
-#[should_panic(expected = "PoolNotDisbursedOrRefunded")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_close_paused_pool_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -547,7 +547,7 @@ fn test_close_paused_pool_fails() {
 
 /// Test 5: Close pool in Completed state fails with PoolNotDisbursedOrRefunded error
 #[test]
-#[should_panic(expected = "PoolNotDisbursedOrRefunded")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_close_completed_pool_fails() {
     let env = Env::default();
     env.mock_all_auths();
@@ -573,7 +573,7 @@ fn test_close_completed_pool_fails() {
 
 /// Test 6: Close pool in Closed state fails with PoolNotDisbursedOrRefunded error
 #[test]
-#[should_panic(expected = "PoolNotDisbursedOrRefunded")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_close_already_closed_pool_fails() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Description

This PR addresses two related contract reliability and indexer visibility issues (#955 and #954):

1. **Introduces a typed `ContractError` enum (#955)**: Replaces ad hoc `panic!("string literal")` calls across contract functions with `env.panic_with_error(ContractError::Variant)`. This makes errors stable, machine-readable, and XDR-encodable for off-chain callers and client SDKs.
2. **Standardizes event topics and adds missing state-change events (#954)**: Introduces `symbol_short!` constants for state-changing operations and emits event logs from functions that were previously un-eventful. Also replaces the inline `Symbol::new` topic in `set_creation_fee` with the shared `FEE_UPDATED` constant.

---

## Deliverables & Changes Made

### 1. `ContractError` Enum (`#955`)
- Defined `#[contracterror]` `ContractError` in `nevo_contract/contracts/hello-world/src/lib.rs` with the following variants:
  - `PoolNotFound = 1`
  - `InvalidPoolState = 2`
  - `UnauthorizedAdmin = 3`
  - `PoolIsClosed = 4`
  - `DuplicateApplication = 5`
  - `StudentHasNotApplied = 6`
  - `OnlyLinkedSchoolCanApprove = 7`
  - `PoolNotDisbursedOrRefunded = 8`
  - `AdminNotSet = 9`
  - `NoUnclaimedFees = 10`
  - `InvalidFee = 11`
  - `PoolNotExpired = 12`
  - `NoContributionToRefund = 13`
  - `SchoolNotRegistered = 14`
- Converted contract functions to use `env.panic_with_error(ContractError::Variant)`.

### 2. Event Emissions & Topic Standardization (`#954`)
- Created named `symbol_short!` topic constants:
  - `APP_APPROVED` (`app_aprvd`)
  - `MILESTONES_SET` (`mile_set`)
  - `FUNDS_CLAIMED` (`fund_clmd`)
  - `FEES_CLAIMED` (`fees_clmd`)
  - `DONATION_REFUND` (`don_refnd`)
  - `DEADLINE_SET` (`ddln_set`)
  - `POOL_STATE_SET` (`pool_stat`)
  - `SCHOOL_REG` (`schl_reg`)
  - `ADMIN_SET` (`admin_set`)
  - `FEE_UPDATED` (`fee_upd`)
- Added event publication (`env.events().publish(...)`) to:
  - `approve_application`
  - `setup_application_milestones`
  - `claim_funds`
  - `claim_protocol_fees`
  - `refund_donation`
  - `set_pool_deadline`
  - `set_pool_state`
  - `register_school`
  - `set_admin`
- Refactored `set_creation_fee` to emit using the `FEE_UPDATED` constant.

### 3. Test Suite Updates
- Updated expected panic assertions in unit tests (`test.rs` and `test_issues.rs`) to match Soroban's `Error(Contract, #N)` host error format for contract errors.

---

## How Has This Been Tested?

- [x] Ran unit test suite: `cargo test --lib` from `nevo_contract/` (44/44 tests passed).
- [x] Verified target build: `cargo build --release --target wasm32-unknown-unknown` passed with no errors.

Closes #955 
Closes #954 
Closes #953 
Closes #952 