### PR TITLE
docs: add SECURITY.md and .github/CODEOWNERS (#963, #964)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# CODEOWNERS for Nevo Repository
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default global code owners
+* @Akshola00
+
+# Frontend application (Next.js)
+/nevo_frontend/ @Akshola00
+
+# Backend API service (NestJS)
+/nevo_server/ @Akshola00
+
+# Soroban Smart Contracts (Rust)
+/nevo_contract/ @Akshola00

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ dist/
 !Contribution.md
 !AGENTS.md
 !Agents.md
+!SECURITY.md
+!security.md
 !docs/pools-page.md
 
 # Local plans — not committed, stays on each contributor's machine

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+The Nevo team and community take the security of our application, backend services, and smart contracts very seriously. We appreciate responsible security research and disclosure.
+
+## Supported Versions
+
+We actively support and maintain the latest release of Nevo on the `main` branch. Security fixes will be applied to the current active components:
+
+| Component | Directory | Supported | Notes |
+| --- | --- | --- | --- |
+| Frontend | `nevo_frontend/` | :white_check_mark: | Next.js frontend application |
+| Backend Server | `nevo_server/` | :white_check_mark: | NestJS API backend |
+| Smart Contract | `nevo_contract/` | :white_check_mark: | Soroban smart contracts on Stellar |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+If you discover a security vulnerability in Nevo (including frontend, backend authentication/authorization, or Soroban smart contracts), please disclose it responsibly using one of the following private methods:
+
+### 1. GitHub Private Vulnerability Reporting (Preferred)
+Submit a private security advisory directly via GitHub:
+1. Navigate to the repository's **Security** tab.
+2. Select **Advisories** and click **Report a vulnerability**.
+3. Fill out the details including proof of concept, impact, and steps to reproduce.
+
+### 2. Contact Maintainers
+If GitHub Private Vulnerability Reporting is unavailable, please reach out directly to the maintainers:
+- Contact Maintainer: [@Akshola00](https://github.com/Akshola00)
+
+## What to Include in a Security Report
+
+To help us evaluate and address the issue efficiently, please include as much of the following as possible:
+
+- **Type of issue**: (e.g. smart contract reentrancy/logic flaw, backend auth bypass, XSS, API key leakage, etc.)
+- **Affected component(s)**: (`nevo_frontend`, `nevo_server`, or `nevo_contract`)
+- **Detailed steps to reproduce** or a minimal Proof of Concept (PoC)
+- **Potential impact** of the vulnerability
+- Any suggested fixes or mitigations (optional)
+
+## Disclosure & Remediation Policy
+
+1. **Acknowledgment**: We aim to acknowledge receipt of your vulnerability report within 48 hours.
+2. **Assessment**: Our maintainers will investigate and verify the report.
+3. **Fix & Patching**: We will work on a patch and notify you when a fix is ready for testing/verification.
+4. **Public Release**: Once the patch is merged and deployed, we will coordinate public disclosure if appropriate and give proper credit to the reporter (unless anonymity is requested).
+
+Thank you for helping keep Nevo and the Stellar ecosystem safe!


### PR DESCRIPTION
## Summary

This PR addresses issues **#963** and **#964** by adding security disclosure documentation and repository code ownership rules.

### Key Changes

- **Root `SECURITY.md` (`#964`)**:
  - Outlines supported component versions (`nevo_frontend/`, `nevo_server/`, `nevo_contract/`).
  - Documents private vulnerability disclosure procedures via GitHub Private Vulnerability Reporting and direct maintainer contact ([@Akshola00](https://github.com/Akshola00)).
  - Details what to include in a security report and disclosure timelines.

- **`.github/CODEOWNERS` (`#963`)**:
  - Maps code ownership for the three top-level project directories (`/nevo_frontend/`, `/nevo_server/`, `/nevo_contract/`) as well as global codebase defaults to maintainer `@Akshola00`.

- **`.gitignore`**:
  - Added `!SECURITY.md` exception so the security policy file is properly tracked by git.

## Related Issues

- Closes #963
- Closes #964
- Closes #962
- Closes #965




## Verification Checklist

- [x] Added `SECURITY.md` at root level with complete vulnerability reporting guidelines.
- [x] Added `.github/CODEOWNERS` covering all top-level project layers.
- [x] Updated `.gitignore` to allow tracking `SECURITY.md`.
- [x] All file paths and GitHub handles verified.
