### PR TITLE
chore: add GitHub community health files and markdown link-check CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behaviour in Nevo
+title: "[Bug] <short description>"
+labels: bug
+assignees: ""
+---
+
+## Layer
+
+Which layer does this bug affect? (check one)
+
+- [ ] `nevo_frontend` — Next.js frontend
+- [ ] `nevo_server` — NestJS backend API
+- [ ] `nevo_contract` — Soroban smart contract (Rust)
+- [ ] Other / unsure
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behaviour
+
+What you expected to happen.
+
+## Actual Behaviour
+
+What actually happened. Include error messages, stack traces, or screenshots where relevant.
+
+## Environment
+
+- OS: [e.g. macOS 14, Ubuntu 22.04]
+- Node version: [e.g. 20.x] (frontend/server bugs)
+- Browser & version: [e.g. Chrome 125] (frontend bugs)
+- Rust/Cargo version: [e.g. 1.78] (contract bugs)
+- Network: [e.g. testnet / pubnet] (contract/frontend bugs)
+
+## Additional Context
+
+Any other context about the problem here (logs, related issues, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for Nevo
+title: "[Feature] <short description>"
+labels: enhancement
+assignees: ""
+---
+
+## Layer
+
+Which layer would this feature primarily touch? (check one)
+
+- [ ] `nevo_frontend` — Next.js frontend
+- [ ] `nevo_server` — NestJS backend API
+- [ ] `nevo_contract` — Soroban smart contract (Rust)
+- [ ] Other / cross-layer (please explain below)
+
+> **Note:** Per the project's contribution convention, each PR may only modify a single layer.
+> If this feature requires changes across multiple layers, please open a separate issue per layer.
+
+## Problem / Motivation
+
+What problem does this feature solve, or what user need does it address?
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+Any alternative solutions or features you have considered.
+
+## Acceptance Criteria
+
+A list of behaviours that must be true for this feature to be considered complete.
+
+- [ ] ...
+- [ ] ...
+
+## Additional Context
+
+Screenshots, mockups, links to related issues, or any other context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Related Issue
+
+Closes #<!-- issue number -->
+
+## Layer Touched
+
+This PR modifies exactly one layer (per the single-layer-per-PR convention in AGENTS.md):
+
+- [ ] `nevo_frontend` — Next.js frontend
+- [ ] `nevo_server` — NestJS backend API
+- [ ] `nevo_contract` — Soroban smart contract (Rust)
+- [ ] Other (docs, CI, repo config — no source layer changed)
+
+> If your changes span more than one source layer, stop and split this PR.
+
+## Checklist
+
+### All PRs
+- [ ] The branch is up to date with `main`
+- [ ] No `.env` files, secrets, or API keys are included
+- [ ] No auto-generated files (`node_modules/`, `target/`, `.next/`, `dist/`) are committed
+
+### Frontend (`nevo_frontend/`) — if applicable
+- [ ] `npm run build` passes locally (run from `nevo_frontend/`)
+- [ ] No TypeScript errors (`npx tsc --noEmit`)
+- [ ] No `MOCK_` constants left in `app/` or `src/store/`
+- [ ] New or updated tests added where appropriate
+
+### Backend (`nevo_server/`) — if applicable
+- [ ] `npm run build` passes locally (run from `nevo_server/`)
+- [ ] No TypeScript errors
+- [ ] New endpoints follow RESTful conventions
+
+### Contract (`nevo_contract/`) — if applicable
+- [ ] `cargo build --release --target wasm32-unknown-unknown` passes
+- [ ] `cargo test --lib` passes — all tests green
+- [ ] No unsafe code introduced without justification
+
+## Testing Notes
+
+<!-- Describe how you tested these changes. Include any manual steps or relevant test output. -->

--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,0 +1,17 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https?://localhost"
+    },
+    {
+      "pattern": "^https?://127\\.0\\.0\\.1"
+    },
+    {
+      "pattern": "^https?://friendbot\\.stellar\\.org"
+    }
+  ],
+  "retryOn429": true,
+  "retryCount": 2,
+  "fallbackRetryDelay": "10s",
+  "aliveStatusCodes": [200, 206]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,16 @@ jobs:
 
       - name: Run tests
         run: cargo test --lib
+
+  markdown-links:
+    name: Markdown — Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/mlc_config.json"

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,15 @@ dist/
 !AGENTS.md
 !Agents.md
 !docs/pools-page.md
+!.github/ISSUE_TEMPLATE/bug_report.md
+!.github/ISSUE_TEMPLATE/feature_request.md
+!.github/PULL_REQUEST_TEMPLATE.md
+!nevo_frontend/README.md
+!nevo_server/README.md
+!nevo_contract/README.md
+!nevo_contract/CONFIGURATION_BOUNDS_TESTS.md
+!nevo_contract/EVENT_EMISSION_TESTS.md
+!nevo_contract/EVENTS_REFERENCE.md
 
 # Local plans — not committed, stays on each contributor's machine
 plans/

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Nevo
 
+[![CI](https://github.com/Web3Novalabs/Nevo/actions/workflows/ci.yml/badge.svg)](https://github.com/Web3Novalabs/Nevo/actions/workflows/ci.yml)
+
 **Nevo** is an open-source donation platform built on Stellar, designed to make fundraising transparent, secure, and efficient through blockchain technology.
 
 ## Overview


### PR DESCRIPTION
Resolves four open issues in a single atomic commit since all changes are repo-configuration / CI work that does not touch any source layer.

---

Issue #966 — Add GitHub issue templates for bug reports and feature requests

Problem: .github/ISSUE_TEMPLATE/ did not exist, so reporters had no structured template guiding them toward the information maintainers need.

What was done:
  • Created .github/ISSUE_TEMPLATE/bug_report.md
    - Prompts for: affected layer (nevo_frontend / nevo_server / nevo_contract), reproduction steps, expected vs actual behaviour, and environment details (OS, Node, browser, Rust, network). • Created .github/ISSUE_TEMPLATE/feature_request.md
    - Prompts for: affected layer with a note about the single-layer- per-PR convention from AGENTS.md, problem/motivation, proposed solution, alternatives considered, and acceptance criteria.

Both templates include a layer selector that mirrors the project's single-layer-per-task convention so that triaging is easier.

---

Issue #967 — Add pull request template reflecting the single-layer-per-PR convention

Problem: .github/PULL_REQUEST_TEMPLATE.md did not exist. AGENTS.md establishes a strict 'never modify multiple layers in a single task' rule, but nothing in the PR flow prompted contributors to confirm this.

What was done:
  • Created .github/PULL_REQUEST_TEMPLATE.md with:
    - Summary and related issue fields.
    - A 'Layer Touched' section with a single-choice layer checklist and an explicit warning to split the PR if multiple source layers are changed.
    - A 'Checklist' section split into three conditional sub-sections: all PRs (branch hygiene, no secrets), frontend-specific (build, tsc, no MOCK_ constants, tests), server-specific (build, tsc, REST conventions), and contract-specific (cargo build, cargo test, no unsafe code).
    - A 'Testing Notes' field for manual testing description.

---

Issue #969 — Add a CI status badge to the root readme.md

Problem: readme.md had no CI status badge, so visitors had no at-a-glance signal of whether the build was passing.

What was done:
  • Added a GitHub Actions badge for ci.yml near the top of readme.md,
    immediately below the # Nevo heading:

      [![CI](https://github.com/Web3Novalabs/Nevo/actions/workflows/ci.yml/badge.svg)](https://github.com/Web3Novalabs/Nevo/actions/workflows/ci.yml)

    The badge links to the Actions run list for ci.yml so a single click
    takes the visitor to the full build history.

---

Issue #972 — Add a markdown link-check CI job and audit existing links

Problem: There was no automated check for broken relative links across the repo's Markdown files, so link rot went unnoticed.

What was done:
  1. Added a new job 'markdown-links' to .github/workflows/ci.yml using the gaurav-nelson/github-action-markdown-link-check@v1 action. - Runs on every push and PR to main (same triggers as the existing frontend / server / contract jobs). - verbose mode on, quiet mode on (clean output — only failures are printed to keep the log readable). - Points to .github/mlc_config.json for configuration.

  2. Created .github/mlc_config.json to configure the checker:
     - Ignores localhost and 127.0.0.1 URLs (dev-only endpoints that will never resolve in CI).
     - Ignores friendbot.stellar.org (Stellar testnet faucet — external service with occasional downtime that would produce flaky results). - retryOn429 + retryCount: 2 to handle transient rate-limiting from external link targets.

  3. Audited all *.md files in the repo for broken relative links: - readme.md → ./docs/pools-page.md  ✓ file exists - readme.md → ./nevo_server/README.md  ✓ file exists No broken relative links were found. The ./BROWSER_COMPATIBILITY.md link mentioned in the issue description does not appear in the current version of nevo_frontend/README.md and required no fix.

  4. Updated .gitignore to add explicit !<path> exceptions for the new template files and the existing layer READMEs. The gitignore had a blanket '*.md' ignore rule with only a handful of exceptions; without these additions the new template files would be silently excluded from the repository.

Closes #966
Closes #967
Closes #969
Closes #972