### PR TITLE
fix: resolve multiple UI issues (#878, #879, #880, #884)

### DIFF
--- a/nevo_frontend/app/pools/[id]/page.tsx
+++ b/nevo_frontend/app/pools/[id]/page.tsx
@@ -231,6 +231,15 @@ function PoolDetailPageContent() {
                 {pool.title}
               </h1>
               <StatusBadge status={pool.status} />
+              <CopyButton
+                text={
+                  typeof window !== 'undefined'
+                    ? window.location.href
+                    : `/pools/${pool.id}`
+                }
+                iconOnly
+                aria-label="Copy pool link"
+              />
             </div>
 
             <div className="mt-2 flex flex-wrap gap-3 text-sm text-[var(--color-text-muted)]">

--- a/nevo_frontend/components/NotificationCenter.tsx
+++ b/nevo_frontend/components/NotificationCenter.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { useNotificationsStore } from '@/src/store/notificationsStore';
+import { ConfirmDialog } from './ConfirmDialog';
 
 export function NotificationCenter() {
   const {
@@ -13,6 +14,7 @@ export function NotificationCenter() {
     clearAll,
   } = useNotificationsStore();
   const [isOpen, setIsOpen] = useState(false);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -87,7 +89,7 @@ export function NotificationCenter() {
                 Mark all read
               </button>
               <button
-                onClick={() => clearAll()}
+                onClick={() => setShowClearConfirm(true)}
                 className="text-error hover:text-error-dark font-medium"
               >
                 Clear all
@@ -190,6 +192,19 @@ export function NotificationCenter() {
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={showClearConfirm}
+        title="Clear all notifications?"
+        message="This action cannot be undone. All your notifications will be permanently removed."
+        confirmLabel="Clear all"
+        variant="danger"
+        onConfirm={() => {
+          clearAll();
+          setShowClearConfirm(false);
+        }}
+        onCancel={() => setShowClearConfirm(false)}
+      />
     </div>
   );
 }

--- a/nevo_frontend/components/Pagination.tsx
+++ b/nevo_frontend/components/Pagination.tsx
@@ -367,6 +367,9 @@ export function Pagination({
         {/* Go-to-page input */}
         {showGoToPage && totalPages > 5 && (
           <div className="flex items-center gap-1.5 ml-2 pl-2 border-l border-[var(--color-border)]">
+            <label htmlFor={`${uid}-goto`} className="sr-only">
+              Go to page
+            </label>
             <label
               htmlFor={`${uid}-goto`}
               className="text-[var(--color-text-muted)] whitespace-nowrap hidden sm:block"

--- a/nevo_frontend/components/form/Textarea.tsx
+++ b/nevo_frontend/components/form/Textarea.tsx
@@ -1,4 +1,9 @@
-import React, { forwardRef, TextareaHTMLAttributes, useId } from 'react';
+import React, {
+  forwardRef,
+  TextareaHTMLAttributes,
+  useId,
+  useState,
+} from 'react';
 import { FormField } from './FormField';
 import { getControlClassName } from './form-styles';
 
@@ -26,6 +31,24 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     const generatedId = useId();
     const id = idProp ?? generatedId;
     const hasError = Boolean(error);
+    const maxLength = props.maxLength;
+    const [charCount, setCharCount] = useState(() => {
+      if (
+        typeof props.defaultValue === 'string' ||
+        typeof props.defaultValue === 'number'
+      ) {
+        return String(props.defaultValue).length;
+      }
+      if (typeof props.value === 'string' || typeof props.value === 'number') {
+        return String(props.value).length;
+      }
+      return 0;
+    });
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setCharCount(e.target.value.length);
+      props.onChange?.(e);
+    };
 
     const textarea = (
       <textarea
@@ -40,24 +63,39 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           `${className} resize-y`.trim()
         )}
         {...props}
+        onChange={handleChange}
       />
     );
 
+    const counter = maxLength ? (
+      <span className="mt-1 block text-right text-xs text-[var(--color-text-muted)]">
+        {charCount}/{maxLength}
+      </span>
+    ) : null;
+
     if (label || helperText || error) {
       return (
-        <FormField
-          id={id}
-          label={label}
-          helperText={helperText}
-          error={error}
-          required={required}
-        >
-          {textarea}
-        </FormField>
+        <div>
+          <FormField
+            id={id}
+            label={label}
+            helperText={helperText}
+            error={error}
+            required={required}
+          >
+            {textarea}
+          </FormField>
+          {counter}
+        </div>
       );
     }
 
-    return textarea;
+    return (
+      <>
+        {textarea}
+        {counter}
+      </>
+    );
   }
 );
 


### PR DESCRIPTION
## Summary

Four UI fixes across the frontend:

### #878 — Add CopyButton to pool detail page
Added a CopyButton (iconOnly) next to the pool title and status badge that copies the current page URL.

### #879 — Add character counter to Textarea
When `maxLength` is provided, a live `current/max` character counter renders below the textarea and updates on every keystroke.

### #880 — Add confirmation dialog to NotificationCenter clearAll
"Clear all" now opens a ConfirmDialog before clearing notifications. Cancelling leaves all notifications intact.

### #884 — Add sr-only label for Pagination 'Go to page' input
Added a visually-hidden (`sr-only`) label for the "Go to page" input that is present regardless of screen size, improving accessibility and testability.

## Verification
- [x] `npm run build` passes
- [x] No visual regressions on desktop or mobile

Closes #878
Closes #879
Closes #880
Closes #884