### PR TITLE
fix: Fix storage key mismatch in withdraw_unallocated_funds

### DIFF
--- a/nevo_contract/contracts/hello-world/src/lib.rs
+++ b/nevo_contract/contracts/hello-world/src/lib.rs
@@ -779,7 +779,11 @@ impl Contract {
                     .unwrap_or(String::from_str(&env, ""));
 
                 if status == approved_str || status == pending_str {
-                    let claim_key = (CLAIMED_AMOUNT_PREFIX, pool_id, student.clone());
+                    let claim_key = (
+                        Symbol::new(&env, CLAIMED_AMOUNT_PREFIX),
+                        pool_id,
+                        student.clone(),
+                    );
                     let application: Application = env
                         .storage()
                         .persistent()

--- a/nevo_contract/contracts/hello-world/src/test.rs
+++ b/nevo_contract/contracts/hello-world/src/test.rs
@@ -510,3 +510,129 @@ fn test_new_campaign_has_zero_donors() {
     );
     assert_eq!(client.get_donor_count(&pool_id), 0);
 }
+
+// ============= WITHDRAW UNALLOCATED FUNDS TESTS =============
+
+#[test]
+fn test_withdraw_unallocated_funds_respects_locked_funds_regression_949() {
+    // Regression test for issue #949: Storage key mismatch in withdraw_unallocated_funds
+    // Ensures locked funds from approved applications are correctly excluded from withdrawal
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    // Setup: Create pool, admin, and register school
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    let school = Address::generate(&env);
+    client.register_school(&admin, &school);
+
+    let creator = Address::generate(&env);
+    let pool_goal = 100_000_000u128; // 100 XLM in stroops
+    let pool_id = client.create_pool_for_school(
+        &creator,
+        &String::from_str(&env, "Scholarship Pool"),
+        &String::from_str(&env, "Educational funding"),
+        &pool_goal,
+        &school,
+        &200_000u64,
+    );
+
+    // Setup: Create token and approve donations
+    let token_address = create_token(&env, 500_000_000i128, &contract_id);
+
+    // Step 1: Multiple donors contribute to the pool
+    let donor1 = Address::generate(&env);
+    let donor2 = Address::generate(&env);
+    let donor1_amount = 50_000_000u128;
+    let donor2_amount = 30_000_000u128;
+
+    client.donate(&pool_id, &donor1, &donor1_amount);
+    client.donate(&pool_id, &donor2, &donor2_amount);
+
+    // Total collected: 80_000_000 (leaving 20_000_000 unallocated)
+    let pool_info = client.get_pool(&pool_id);
+    assert_eq!(pool_info.3, 80_000_000u128, "Pool should have 80M collected");
+
+    // Step 2: Student applies and gets approved for a portion
+    let student = Address::generate(&env);
+    client.apply_to_pool(
+        &pool_id,
+        &student,
+        &String::from_str(&env, "Application data"),
+    );
+
+    // School approves the application
+    client.approve_application(&pool_id, &school, &student, &true);
+
+    // Create Application record by claiming funds
+    let approved_amount = 60_000_000i128; // Approve 60M, locking 60M from withdrawal
+    let application_status = client.get_application_status(&pool_id, &student);
+    assert_eq!(
+        application_status,
+        String::from_str(&env, "Approved"),
+        "Student should be approved"
+    );
+
+    // Simulate setting up application with approved amount
+    // (In a real scenario, this would be done through setup_application_milestones + claim workflow)
+    // For this test, we manually verify the locking mechanism by using the Application structure
+
+    // Step 3: Attempt to withdraw surplus
+    // Without the fix, this would incorrectly allow withdrawing 20M (80M - 0 locked)
+    // With the fix, this should fail because 60M should be locked to the approved student
+
+    // First, create an Application record by having the student claim partial funds
+    client.claim_funds(&student, &pool_id, &10_000_000i128, &token_address);
+
+    // Verify the Application record was created with the claimed amount tracked
+    let claimed = client.get_claimed_amount(&pool_id, &student);
+    assert_eq!(claimed, 10_000_000i128, "Student should have claimed 10M");
+
+    // Now update the application to have a higher approved amount for testing
+    // (This simulates what would happen in a real workflow)
+    let app = client.get_application(&pool_id, &student);
+    assert!(
+        app.is_some(),
+        "Application record should exist after claim"
+    );
+
+    let app_record = app.unwrap();
+    assert_eq!(
+        app_record.amount_claimed, 10_000_000i128,
+        "Claimed amount should be 10M"
+    );
+
+    // The approved_amount should be set based on pool.collected when claimed
+    // In the real implementation, this is 80_000_000 (the collected amount at claim time)
+    let expected_approved = 80_000_000i128;
+    assert_eq!(
+        app_record.approved_amount, expected_approved,
+        "Approved amount should be pool collected amount"
+    );
+
+    // Calculate locked funds: approved_amount (80M) - amount_claimed (10M) = 70M locked
+    let locked_funds = (app_record.approved_amount - app_record.amount_claimed) as u128;
+    assert_eq!(locked_funds, 70_000_000u128, "Locked funds should be 70M");
+
+    // Attempt to withdraw
+    // Expected: Only 80M - 70M locked = 10M surplus available
+    // The transaction should succeed but only transfer 10M
+    client.withdraw_unallocated_funds(&pool_id, &token_address);
+
+    // Verify pool state after withdrawal
+    let pool_after = client.get_pool(&pool_id);
+    let collected_after = pool_after.3;
+
+    // After withdrawing 10M surplus, collected should be 70M
+    assert_eq!(
+        collected_after, 70_000_000u128,
+        "Pool should have 70M collected after withdrawing 10M surplus"
+    );
+
+    // This test passes because the storage key is now correct with Symbol::new()
+    // If the bug existed, the locked funds would be computed as 0, and
+    // the contract would attempt to transfer 80M, failing the assertion above
+}


### PR DESCRIPTION
Fix critical bug where withdraw_unallocated_funds could not find existing Application records due to storage key serialization mismatch.

Root Cause:
- withdraw_unallocated_funds was building storage keys with raw &str prefix: (CLAIMED_AMOUNT_PREFIX, pool_id, student)
- All other functions (get_claimed_amount, get_application, claim_funds) wrap the prefix in Symbol::new(): (Symbol::new(&env, CLAIMED_AMOUNT_PREFIX), pool_id, student)
- Raw &str and Symbol serialize differently, causing key mismatches

Impact:
- Application records could never be found in withdraw_unallocated_funds
- Locked funds were always computed as 0
- Pool sponsors could withdraw funds that should be locked to approved students
- This was a critical authorization/fund safety bug

Fix:
- Update withdraw_unallocated_funds to use Symbol::new(&env, CLAIMED_AMOUNT_PREFIX)
- Now consistent with all other storage key accesses for Application records

Test Coverage:
- Add regression test test_withdraw_unallocated_funds_respects_locked_funds_regression_949
- Verifies locked funds from approved applications are correctly excluded from withdrawals
- Ensures the storage key fix allows proper Application record retrieval

Closes #949