### PR TITLE
fix(frontend): add copy button for donation tx hash

### DIFF
--- a/nevo_frontend/components/DonateModal.tsx
+++ b/nevo_frontend/components/DonateModal.tsx
@@ -13,6 +13,7 @@ import { useDonationsStore } from '@/src/store/donationsStore';
 import { contractService } from '@/lib/contract-service';
 import { parseApiError } from '@/lib/errors';
 import type { Pool } from '@/src/store/poolsStore';
+import { CopyButton } from './CopyButton';
 import { WalletAddress } from './WalletAddress';
 
 const NETWORK_PASSPHRASE =
@@ -408,14 +409,24 @@ export function DonateModal({
                 to <span className="font-medium">{pool.title}</span>.
               </p>
               {txHash && (
-                <a
-                  href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mt-2 inline-block font-mono text-xs text-brand-600 hover:underline"
-                >
-                  {txHash.slice(0, 10)}…{txHash.slice(-6)}
-                </a>
+                <div className="mt-2 inline-flex items-center gap-2">
+                  <a
+                    href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-mono text-xs text-brand-600 hover:underline"
+                  >
+                    {txHash.slice(0, 10)}…{txHash.slice(-6)}
+                  </a>
+                  <CopyButton
+                    text={txHash}
+                    label="Copy hash"
+                    copiedLabel="Copied"
+                    iconOnly
+                    aria-label="Copy transaction hash"
+                    className="shrink-0"
+                  />
+                </div>
               )}
             </div>
             <div className="mt-2 flex w-full gap-3">


### PR DESCRIPTION
closes #881 

# Summary of changes:
Added a compact copy button next to the transaction hash on the donation success screen.
Reused the existing CopyButton and clipboard hook pattern already used in the frontend.
Kept the existing Stellar Expert link and truncated hash display intact.

# Reason for the changes:
Users needed a fast way to copy the full transaction hash directly from the success state without manually selecting text.
This improves usability while preserving the current donation flow and external explorer link.